### PR TITLE
Code-style fixes, test import consistency, banned functionality, room-wide message notifications and typing notifications 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ and horizontally scalable WebSocket messaging using Redis Pub/Sub and RabbitMQ.
 | CI/CD             | GitHub Actions                            |
 | Rate Limiting     | Bucket4j                                  |
 | Code Quality      | SonarCloud                                |
+| Testing           | JUnit 6, MockK                            |
+| Load Testing      | k6                                        |
 
 ---
 
@@ -132,23 +134,29 @@ Exceeded requests return `429 Too Many Requests`.
 
 **WebSocket Events**
 
-| Direction       | Type              | Description                                              |
-|-----------------|-------------------|----------------------------------------------------------|
-| Client → Server | `MESSAGE`         | Send a chat message to a room                            |
-| Client → Server | `JOIN`            | Join a room WebSocket session                            |
-| Client → Server | `LEAVE`           | Leave a room WebSocket session                           |
-| Client → Server | `PING`            | Keep-alive heartbeat; resets session TTL                 |
-| Server → Client | `MESSAGE`         | Chat message broadcast                                   |
-| Server → Client | `JOIN` / `LEAVE`  | User join/leave announcement broadcast to room           |
-| Server → Client | `ROOM_MEMBERS`    | Full member snapshot sent once to the joining session    |
-| Server → Client | `ROOM_PRESENCE`   | Lightweight online/offline update for a room member      |
-| Server → Client | `FRIEND_PRESENCE` | Friend online/offline status update                      |
-| Server → Client | `FRIEND_ADDED`    | Notifies both sides when a friend request is accepted    |
-| Server → Client | `FRIEND_REMOVED`  | Notifies both sides when a friendship is removed         |
-| Server → Client | `ROOM_ACTION`     | Kick or ban notification sent to the target user         |
-| Server → Client | `ROOM_DELETED`    | Room deletion notification sent to all members           |
-| Server → Client | `pong`            | Response to client `PING`                                |
-| Server → Client | `ERROR`           | Structured error with HTTP status code and message       |
+| Direction       | Type                | Description                                                        |
+|-----------------|---------------------|--------------------------------------------------------------------|
+| Client → Server | `MESSAGE`           | Send a chat message to a room                                      |
+| Client → Server | `JOIN`              | Join a room WebSocket session                                      |
+| Client → Server | `LEAVE`             | Leave a room WebSocket session                                     |
+| Client → Server | `PING`              | Keep-alive heartbeat; resets session TTL                           |
+| Server → Client | `MESSAGE`           | Chat message broadcast                                             |
+| Server → Client | `JOIN` / `LEAVE`    | User join/leave announcement broadcast to room                     |
+| Server → Client | `ROOM_JOINED`       | Full room snapshot (members, role, encryption) sent on room join   |
+| Server → Client | `ROOM_PRESENCE`     | Lightweight online/offline update for a room member                |
+| Server → Client | `ROOM_ACTION`       | Kick or ban notification sent to the target user                   |
+| Server → Client | `ROOM_DELETED`      | Room deletion notification sent to all members                     |
+| Server → Client | `FRIEND_PRESENCE`   | Friend online/offline status update                                |
+| Server → Client | `FRIEND_SNAPSHOT`   | Full friend list with online status, sent on connect               |
+| Server → Client | `FRIEND_ADDED`      | Notifies both sides when a friend request is accepted              |
+| Server → Client | `FRIEND_REMOVED`    | Notifies both sides when a friendship is removed                   |
+| Server → Client | `INVITE_RECEIVED`   | New invite notification with type, sender, and room details        |
+| Server → Client | `INVITE_ACCEPTED`   | Notifies sender when their invite is accepted                      |
+| Server → Client | `PENDING_INVITES`   | Full pending invite list snapshot sent on connect                  |
+| Server → Client | `USER_ROLE_CHANGED` | Notifies user of a role promotion or demotion in a room            |
+| Server → Client | `BANNED`            | Notifies user they have been banned from the application           |
+| Server → Client | `pong`              | Response to client `PING`                                          |
+| Server → Client | `ERROR`             | Structured error with HTTP status code and message                 |
 
 ---
 
@@ -236,6 +244,8 @@ Encryption is **optional** and configured per room.
 - Login with an unknown username or incorrect password returns `401 Unauthorized`.
 - Users can retrieve and update their own profile fields (bio, avatar, etc.) and change their password.
 - Account deletion preserves chat history — messages are reassigned to a sentinel `[deleted]` user rather than removed.
+- Global role promotions and demotions send the affected user a `USER_ROLE_CHANGED` notification.
+- Global bans send the affected user a `BANNED` notification.
 
 ---
 
@@ -261,7 +271,7 @@ User presence is tracked using Redis.
 - Stale presence keys from previous server runs are cleared on startup.
 
 Room presence events are broadcast to all members of a room when a user connects or disconnects.
-On room join, a full `ROOM_MEMBERS` snapshot is sent to the joining session. Subsequent presence updates use a lightweight `ROOM_PRESENCE` event containing only the user ID and online status.
+On room join, a full `ROOM_JOINED` snapshot is sent to the joining session. Subsequent presence updates use a lightweight `ROOM_PRESENCE` event containing only the user ID and online status.
 
 On WebSocket connect, a `FRIEND_PRESENCE` snapshot is sent to the session with the current online status of all friends, so clients have accurate presence state immediately without waiting for a change event.
 

--- a/src/main/kotlin/com/blikeng/chatapp/controllers/AuthController.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/controllers/AuthController.kt
@@ -1,5 +1,6 @@
 package com.blikeng.chatapp.controllers
 
+import com.blikeng.chatapp.dtos.auth.AuthDTO
 import com.blikeng.chatapp.dtos.auth.LoginDto
 import com.blikeng.chatapp.security.UserRole
 import com.blikeng.chatapp.services.AuthService
@@ -64,8 +65,8 @@ class AuthController(
     }
 
     @GetMapping("/auth")
-    fun auth(): ResponseEntity<UserRole> {
-        return ResponseEntity.ok(userService.getRole())
+    fun auth(): ResponseEntity<AuthDTO> {
+        return ResponseEntity.ok(userService.authenticate())
     }
 
     private fun makeCookie(token: String, maxAge: Long): ResponseCookie {

--- a/src/main/kotlin/com/blikeng/chatapp/dtos/auth/AuthDTO.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/dtos/auth/AuthDTO.kt
@@ -1,0 +1,10 @@
+package com.blikeng.chatapp.dtos.auth
+
+import com.blikeng.chatapp.security.UserRole
+import java.util.UUID
+
+data class AuthDTO (
+    val userId: UUID,
+    val username: String,
+    val userRole: UserRole
+)

--- a/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsBannedEvent.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsBannedEvent.kt
@@ -1,0 +1,7 @@
+package com.blikeng.chatapp.dtos.websocket
+
+data class WsBannedEvent (
+    val type: String = "BANNED",
+    val byUsername: String,
+    val reason: String,
+)

--- a/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsChat.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsChat.kt
@@ -1,9 +1,11 @@
 package com.blikeng.chatapp.dtos.websocket
 
 import java.time.Instant
+import java.util.UUID
 
 data class WsChat(
     val type: String = "MESSAGE",
+    val userId: UUID?,
     val username: String,
     val content: String,
     val timestamp: Instant

--- a/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsMessageNotification.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsMessageNotification.kt
@@ -1,0 +1,11 @@
+package com.blikeng.chatapp.dtos.websocket;
+
+import java.util.UUID;
+
+data class WsMessageNotification (
+        val type: String = "MESSAGE_NOTIFICATION",
+        val roomId: UUID,
+        val roomName: String,
+        val username: String,
+        val message: String
+)

--- a/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsTyping.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsTyping.kt
@@ -1,0 +1,10 @@
+package com.blikeng.chatapp.dtos.websocket
+
+import java.util.UUID
+
+data class WsTyping(
+    val type: String = "TYPING",
+    val userId: UUID,
+    val roomId: UUID,
+    val username: String,
+)

--- a/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsUserRoleChanged.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/dtos/websocket/WsUserRoleChanged.kt
@@ -1,0 +1,13 @@
+package com.blikeng.chatapp.dtos.websocket
+
+import com.blikeng.chatapp.dtos.room.RoleAction
+import com.blikeng.chatapp.security.UserRole
+import java.util.UUID
+
+data class WsUserRoleChanged (
+    val type: String = "USER_ROLE_CHANGED",
+    val userId: UUID,
+    val byUsername: String,
+    val newRole: UserRole,
+    val action: RoleAction
+)

--- a/src/main/kotlin/com/blikeng/chatapp/events/UserBannedEvent.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/events/UserBannedEvent.kt
@@ -1,0 +1,9 @@
+package com.blikeng.chatapp.events
+
+import java.util.UUID
+
+data class UserBannedEvent (
+    val userId: UUID,
+    val byUsername: String,
+    val reason: String,
+)

--- a/src/main/kotlin/com/blikeng/chatapp/events/UserLeftRoomEvent.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/events/UserLeftRoomEvent.kt
@@ -1,0 +1,9 @@
+package com.blikeng.chatapp.events
+
+import java.util.UUID
+
+data class UserLeftRoomEvent(
+    val userId: UUID,
+    val username: String,
+    val roomId: UUID,
+)

--- a/src/main/kotlin/com/blikeng/chatapp/events/UserRoleChangedEvent.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/events/UserRoleChangedEvent.kt
@@ -1,0 +1,12 @@
+package com.blikeng.chatapp.events
+
+import com.blikeng.chatapp.dtos.room.RoleAction
+import com.blikeng.chatapp.security.UserRole
+import java.util.UUID
+
+data class UserRoleChangedEvent (
+    val userId: UUID,
+    val byUsername: String,
+    val newRole: UserRole,
+    val action: RoleAction
+)

--- a/src/main/kotlin/com/blikeng/chatapp/messaging/redis/LocalBroadcaster.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/messaging/redis/LocalBroadcaster.kt
@@ -24,7 +24,7 @@ class LocalBroadcaster(
 
     fun broadcastRaw(roomId: UUID, payload: String) {
         val message = TextMessage(payload)
-        chatService.rooms[roomId]?.forEach { session ->
+        chatService.sessionsInRooms[roomId]?.forEach { session ->
             broadcastExecutor.execute {
                 synchronized(session) {
                     if (session.isOpen) {

--- a/src/main/kotlin/com/blikeng/chatapp/messaging/redis/PresenceHandler.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/messaging/redis/PresenceHandler.kt
@@ -57,7 +57,8 @@ class PresenceHandler(
     fun getOnlineUsers(userIds: List<UUID>): Set<UUID> {
         if (userIds.isEmpty()) return emptySet()
         val keys = userIds.map { PresenceKeys.userPresence(it) }
-        val values = redisTemplate.opsForValue().multiGet(keys) ?: return emptySet()
+        val values = redisTemplate.opsForValue().multiGet(keys)?.toList() ?: return emptySet()
+
         return userIds.zip(values)
             .filter { (_, v) -> v?.toLongOrNull()?.let { it > 0 } == true }
             .map { (id, _) -> id }

--- a/src/main/kotlin/com/blikeng/chatapp/messaging/redis/PresenceKeys.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/messaging/redis/PresenceKeys.kt
@@ -9,4 +9,5 @@ object PresenceKeys {
     fun userPresence(userId: UUID): String = "presence:user:$userId"
     fun userChannel(userId: UUID): String = "user:$userId"
     fun roomChannel(roomId: UUID): String = "room:$roomId"
+    fun roomMembersKey(roomId: UUID): String = "room:$roomId:members"
 }

--- a/src/main/kotlin/com/blikeng/chatapp/repositories/UserRoomRepository.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/repositories/UserRoomRepository.kt
@@ -48,6 +48,12 @@ interface UserRoomRepository: JpaRepository<UserRoomEntity, UserRoomId> {
     fun findAllIdRoomIdsByIdUserId(userId: UUID): List<UUID>
 
     @Query("""
+        SELECT ur.id.userId
+        FROM UserRoomEntity ur
+        WHERE ur.id.roomId = :roomId""")
+    fun findAllIdUserIdsByIdRoomId(roomId: UUID): List<UUID>
+
+    @Query("""
         SELECT ur.id.roomId as roomId, u.username as username
         FROM UserRoomEntity ur
         JOIN UserEntity u ON u.id = ur.id.userId

--- a/src/main/kotlin/com/blikeng/chatapp/security/auth/AuthHandshakeInterceptor.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/security/auth/AuthHandshakeInterceptor.kt
@@ -34,7 +34,7 @@ class AuthHandshakeInterceptor(
 
         val (username, id) = jwtService.validateToken(token.value) ?: return false
 
-        if (userRevocationService.isRevoked(id)) return false
+        if (userRevocationService.isRevoked(id) || userRevocationService.isBanned(id)) return false
 
         attributes["userId"] = id
         attributes["username"] = username

--- a/src/main/kotlin/com/blikeng/chatapp/security/auth/JwtAuthFilter.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/security/auth/JwtAuthFilter.kt
@@ -4,6 +4,9 @@ import com.blikeng.chatapp.services.UserRevocationService
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.env.Environment
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
@@ -18,6 +21,7 @@ import org.springframework.web.filter.OncePerRequestFilter
 class JwtAuthFilter(
     private val jwtService: JwtService,
     private val userRevocationService: UserRevocationService,
+    private val environment: Environment,
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(
@@ -33,17 +37,25 @@ class JwtAuthFilter(
             val principal = jwtService.validateToken(token)
 
             if (principal != null && !userRevocationService.isRevoked(principal.userId)) {
-                val authorities = listOf(
-                    SimpleGrantedAuthority("ROLE_${principal.role}")
-                )
-
-                val auth = UsernamePasswordAuthenticationToken(
-                    principal.userId,
-                    principal.username,
-                    authorities
-                )
-
-                SecurityContextHolder.getContext().authentication = auth
+                if (userRevocationService.isBanned(principal.userId)) {
+                    val isProd = environment.activeProfiles.contains("prod")
+                    val cookie = ResponseCookie.from("AUTH", "")
+                        .httpOnly(true)
+                        .secure(isProd)
+                        .path("/")
+                        .sameSite("Strict")
+                        .maxAge(0)
+                        .build()
+                    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString())
+                } else {
+                    val authorities = listOf(SimpleGrantedAuthority("ROLE_${principal.role}"))
+                    val auth = UsernamePasswordAuthenticationToken(
+                        principal.userId,
+                        principal.username,
+                        authorities
+                    )
+                    SecurityContextHolder.getContext().authentication = auth
+                }
             }
         }
 

--- a/src/main/kotlin/com/blikeng/chatapp/services/AdministrationService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/AdministrationService.kt
@@ -16,10 +16,13 @@ import com.blikeng.chatapp.errors.InvalidUserException
 import com.blikeng.chatapp.errors.NotBannedException
 import com.blikeng.chatapp.errors.NotPermittedException
 import com.blikeng.chatapp.errors.UserNotFoundException
+import com.blikeng.chatapp.events.UserBannedEvent
+import com.blikeng.chatapp.events.UserRoleChangedEvent
 import com.blikeng.chatapp.repositories.UserBanRepository
 import com.blikeng.chatapp.repositories.UserRepository
 import com.blikeng.chatapp.security.UserRole
 import com.blikeng.chatapp.security.auth.getId
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,7 +31,8 @@ import java.util.*
 @Service
 class AdministrationService(
     val userRepository: UserRepository,
-    val userBanRepository: UserBanRepository
+    val userBanRepository: UserBanRepository,
+    val eventPublisher: ApplicationEventPublisher
 ) {
     fun getElevatedUsers(): List<ElevatedUserDTO> {
         return userRepository.findAllByRoleNot(UserRole.USER).map { user ->
@@ -85,9 +89,15 @@ class AdministrationService(
 
         userRepository.save(target)
 
-        // TODO: send notification to target
+        eventPublisher.publishEvent(UserRoleChangedEvent(
+            userId = targetId,
+            byUsername = user.username,
+            newRole = newRole,
+            action = userRoleDTO.action,
+        ))
     }
 
+    @Transactional
     fun banUser(banUserDTO: BanUserDTO) {
         val user = userRepository.findById(getId()).orElseThrow { InvalidUserException() }
         val targetId = try {
@@ -110,6 +120,12 @@ class AdministrationService(
         )
 
         userBanRepository.save(ban)
+
+        eventPublisher.publishEvent(UserBannedEvent(
+            userId = targetId,
+            byUsername = user.username,
+            reason = banUserDTO.reason ?: "No reason provided"
+        ))
     }
 
     fun unbanUser(userIdDTO: UserIdDTO) {

--- a/src/main/kotlin/com/blikeng/chatapp/services/AdministrationService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/AdministrationService.kt
@@ -123,8 +123,8 @@ class AdministrationService(
         val ban = userBanRepository.findById(targetId).orElseThrow { NotBannedException() }
         val banner = userRepository.findById(ban.bannedBy).orElse(null)
 
-        if (banner != null) {
-            if (!checkRequiredRole(banner.role, user.role)) throw InvalidUnbanException()
+        if (banner != null && !checkRequiredRole(banner.role, user.role)) {
+            throw InvalidUnbanException()
         }
 
         userBanRepository.delete(ban)

--- a/src/main/kotlin/com/blikeng/chatapp/services/AdministrationService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/AdministrationService.kt
@@ -32,7 +32,8 @@ import java.util.*
 class AdministrationService(
     val userRepository: UserRepository,
     val userBanRepository: UserBanRepository,
-    val eventPublisher: ApplicationEventPublisher
+    val eventPublisher: ApplicationEventPublisher,
+    val userRevocationService: UserRevocationService,
 ) {
     fun getElevatedUsers(): List<ElevatedUserDTO> {
         return userRepository.findAllByRoleNot(UserRole.USER).map { user ->
@@ -144,6 +145,7 @@ class AdministrationService(
         }
 
         userBanRepository.delete(ban)
+        userRevocationService.unRevokeBanned(targetId)
     }
 
     fun getAllUserBans(page: Int, size: Int): List<BannedUserDTO> {

--- a/src/main/kotlin/com/blikeng/chatapp/services/ChatService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/ChatService.kt
@@ -146,11 +146,13 @@ class ChatService (
 
         if (message.type == "MESSAGE") addMessage(message, username)
 
-        val sendMessage = if (message.type == "MESSAGE") {
-            WsChat(content = message.content, userId = userId, username = username, type = message.type, timestamp = timestamp)
-        } else {
-            WsChat(content = message.content, userId = null, username = "Server", type = message.type, timestamp = timestamp)
-        }
+        val sendMessage = WsChat(
+            content = message.content,
+            userId = userId,
+            username = username,
+            type = message.type,
+            timestamp = timestamp
+        )
 
         val json = objectMapper.writeValueAsString(sendMessage)
 
@@ -172,6 +174,7 @@ class ChatService (
 
     fun addMessage(message: ReceivedMessage, username: String){
         val room = roomRepository.findById(message.roomId).orElseThrow { RoomNotFoundException() }
+        roomNameMap[room.id] = room.name
 
         val messageId = UUID.randomUUID()
 
@@ -225,16 +228,27 @@ class ChatService (
 
         val buffered = if (room.encrypted) {
             getPendingMessages(roomId).map { message ->
-                if (message.ciphertext == null || message.nonce == null) throw InvalidMessageException()
-
-                SendMessageDTO(
-                    id = message.id,
-                    roomId = message.roomId,
-                    userId = message.userId,
-                    username = message.username,
-                    message = encrypt.decrypt(message.ciphertext, message.nonce, aad = configureAad(roomId, message.id, message.userId)),
-                    timestamp = message.timestamp,
-                )
+                if (message.ciphertext != null && message.nonce != null) {
+                    SendMessageDTO(
+                        id = message.id,
+                        roomId = message.roomId,
+                        userId = message.userId,
+                        username = message.username,
+                        message = encrypt.decrypt(message.ciphertext, message.nonce, aad = configureAad(roomId, message.id, message.userId)),
+                        timestamp = message.timestamp,
+                    )
+                } else if (message.message != null) {
+                    SendMessageDTO(
+                        id = message.id,
+                        roomId = message.roomId,
+                        userId = message.userId,
+                        username = message.username,
+                        message = message.message,
+                        timestamp = message.timestamp,
+                    )
+                } else {
+                    throw InvalidMessageException()
+                }
             }
         } else {
             getPendingMessages(roomId).map { message ->

--- a/src/main/kotlin/com/blikeng/chatapp/services/ChatService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/ChatService.kt
@@ -20,10 +20,11 @@ import com.blikeng.chatapp.repositories.RoomRepository
 import com.blikeng.chatapp.repositories.UserRoomRepository
 import com.blikeng.chatapp.security.crypto.ChatEncrypt
 import com.blikeng.chatapp.dtos.room.RoomDTO
+import com.blikeng.chatapp.dtos.websocket.WsMessageNotification
 import com.blikeng.chatapp.dtos.websocket.WsTyping
+import com.blikeng.chatapp.messaging.redis.PresenceKeys
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.data.domain.PageRequest
@@ -31,6 +32,7 @@ import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
+import java.time.Duration
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -54,11 +56,15 @@ class ChatService (
     private val userService: UserService,
     meterRegistry: MeterRegistry,
 ) {
-    val rooms = ConcurrentHashMap<UUID, MutableSet<WebSocketSession>>()
-    private val roomListType = object : TypeReference<List<RoomDTO>>() {}
+    val sessionsInRooms = ConcurrentHashMap<UUID, MutableSet<WebSocketSession>>()
+    private val roomNameMap = ConcurrentHashMap<UUID, String>()
+
+    private val userRoomListType = object : TypeReference<List<RoomDTO>>() {}
+    private val roomMemberListType = object : TypeReference<List<UUID>>() {}
+    private val roomMembersCacheTTL = Duration.ofMinutes(10)
 
     init {
-        meterRegistry.gauge("chat.rooms", rooms) { it.size.toDouble() }
+        meterRegistry.gauge("chat.rooms", sessionsInRooms) { it.size.toDouble() }
     }
 
     // ==========================
@@ -72,7 +78,8 @@ class ChatService (
 
         val room = roomRepository.findById(roomId).orElseThrow { RoomNotFoundException() }
 
-        rooms.computeIfAbsent(roomId) { CopyOnWriteArraySet() }.add(session)
+        sessionsInRooms.computeIfAbsent(roomId) { CopyOnWriteArraySet() }.add(session)
+        roomNameMap[roomId] = room.name
 
         synchronized(session) {
             if (session.isOpen) {
@@ -97,15 +104,15 @@ class ChatService (
     }
 
     fun leaveRoom(roomId: UUID, session: WebSocketSession) {
-        rooms[roomId]?.remove(session)
+        sessionsInRooms[roomId]?.remove(session)
 
-        if (rooms[roomId]?.isEmpty() == true) {
-            rooms.remove(roomId)
+        if (sessionsInRooms[roomId]?.isEmpty() == true) {
+            sessionsInRooms.remove(roomId)
         }
     }
 
     fun removeSessionFromRooms(session: WebSocketSession) {
-        rooms.entries.removeIf { (_, sessions) ->
+        sessionsInRooms.entries.removeIf { (_, sessions) ->
             sessions.remove(session)
             sessions.isEmpty()
         }
@@ -114,7 +121,7 @@ class ChatService (
     fun notifyRoomPresence(userId: UUID, online: Boolean) {
         val cached = redisTemplate.opsForValue()["user:$userId:rooms"]
         val roomIds = if (cached != null) {
-            objectMapper.readValue(cached, roomListType).map { UUID.fromString(it.roomId) }
+            objectMapper.readValue(cached, userRoomListType).map { UUID.fromString(it.roomId) }
         } else {
             userRoomRepository.findAllIdRoomIdsByIdUserId(userId)
         }
@@ -148,6 +155,19 @@ class ChatService (
         val json = objectMapper.writeValueAsString(sendMessage)
 
         redisTemplate.convertAndSend("room:${roomId}", json)
+
+        val roomMembers = getRoomMemberIds(roomId)
+        val roomWideJson = objectMapper.writeValueAsString(
+            WsMessageNotification(
+                roomId = roomId,
+                roomName = roomNameMap[roomId] ?: "Unknown room",
+                username = username,
+                message = message.content,
+            )
+        )
+        for (memberId in roomMembers) {
+            if (presenceHandler.isUserOnline(memberId)) redisTemplate.convertAndSend("user:$memberId", roomWideJson)
+        }
     }
 
     fun addMessage(message: ReceivedMessage, username: String){
@@ -275,6 +295,15 @@ class ChatService (
     // ==========================
     // Helper methods
     // ==========================
+    fun getRoomMemberIds(roomId: UUID): List<UUID> {
+        val key = PresenceKeys.roomMembersKey(roomId)
+        val cached = redisTemplate.opsForValue()[key]
+        if (cached != null) return objectMapper.readValue(cached, roomMemberListType)
+        val ids = userRoomRepository.findAllIdUserIdsByIdRoomId(roomId)
+        redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(ids), roomMembersCacheTTL)
+        return ids
+    }
+
     private fun getPendingMessages(roomId: UUID): List<RabbitMessageDTO> {
         return redisTemplate.opsForList()
             .range("chat.peek.$roomId", 0, -1)

--- a/src/main/kotlin/com/blikeng/chatapp/services/ChatService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/ChatService.kt
@@ -111,7 +111,7 @@ class ChatService (
     }
 
     fun notifyRoomPresence(userId: UUID, online: Boolean) {
-        val cached = redisTemplate.opsForValue().get("user:$userId:rooms")
+        val cached = redisTemplate.opsForValue()["user:$userId:rooms"]
         val roomIds = if (cached != null) {
             objectMapper.readValue(cached, roomListType).map { UUID.fromString(it.roomId) }
         } else {

--- a/src/main/kotlin/com/blikeng/chatapp/services/ChatService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/ChatService.kt
@@ -20,6 +20,7 @@ import com.blikeng.chatapp.repositories.RoomRepository
 import com.blikeng.chatapp.repositories.UserRoomRepository
 import com.blikeng.chatapp.security.crypto.ChatEncrypt
 import com.blikeng.chatapp.dtos.room.RoomDTO
+import com.blikeng.chatapp.dtos.websocket.WsTyping
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.Gauge
@@ -130,7 +131,7 @@ class ChatService (
     // ==========================
     // Message publishing and fetching
     // ==========================
-    fun broadcast(roomId: UUID, message: ReceivedMessage, username: String) {
+    fun broadcast(roomId: UUID, userId: UUID, message: ReceivedMessage, username: String) {
         val timestamp = Instant.now()
         if (!userRoomRepository.existsByIdUserIdAndIdRoomId(message.userId, roomId)) throw RoomNotFoundException()
 
@@ -139,9 +140,9 @@ class ChatService (
         if (message.type == "MESSAGE") addMessage(message, username)
 
         val sendMessage = if (message.type == "MESSAGE") {
-            WsChat(content = message.content, username = username, type = message.type, timestamp = timestamp)
+            WsChat(content = message.content, userId = userId, username = username, type = message.type, timestamp = timestamp)
         } else {
-            WsChat(content = message.content, username = "Server", type = message.type, timestamp = timestamp)
+            WsChat(content = message.content, userId = null, username = "Server", type = message.type, timestamp = timestamp)
         }
 
         val json = objectMapper.writeValueAsString(sendMessage)
@@ -232,6 +233,18 @@ class ChatService (
             .distinctBy { it.id }
             .sortedBy { it.timestamp }
             .takeLast(size)
+    }
+
+    fun notifyTyping(roomId: UUID, userId: UUID, username: String) {
+        val payload = objectMapper.writeValueAsString(
+            WsTyping(
+                userId = userId,
+                roomId = roomId,
+                username = username
+            )
+        )
+
+        redisTemplate.convertAndSend("room:$roomId", payload)
     }
 
     private fun toSendMessageDTO(message: ChatEntity, encrypted: Boolean): SendMessageDTO {

--- a/src/main/kotlin/com/blikeng/chatapp/services/FriendService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/FriendService.kt
@@ -168,7 +168,7 @@ class FriendService(
 
     private fun getCachedFriendIds(userId: UUID): List<UUID> {
         val key = "user:$userId:friends"
-        val cached = redisTemplate.opsForValue().get(key)
+        val cached = redisTemplate.opsForValue()[key]
         if (cached != null) return objectMapper.readValue(cached, friendIdListType)
 
         val friendIds = friendsRepository.findFriendsForUser(userId).map { friendship ->

--- a/src/main/kotlin/com/blikeng/chatapp/services/InviteService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/InviteService.kt
@@ -72,7 +72,7 @@ class InviteService(
 
     fun getPendingInvites(userId: UUID): List<PendingInviteDTO> {
         val key = "user:$userId:pending_invites"
-        val cached = redisTemplate.opsForValue().get(key)
+        val cached = redisTemplate.opsForValue()[key]
         if (cached != null) return objectMapper.readValue(cached, pendingInviteListType)
 
         val invites = inviteRepository.findByToUserIdAndStatus(userId, InviteStatus.PENDING).map {

--- a/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
@@ -21,6 +21,7 @@ import com.blikeng.chatapp.events.UserRemovedEvent
 import com.blikeng.chatapp.events.UserRoleChangedEvent
 import com.blikeng.chatapp.messaging.redis.PresenceHandler
 import com.blikeng.chatapp.messaging.redis.PresenceKeys
+import com.blikeng.chatapp.websocket.SessionRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.time.Instant
 import org.springframework.data.redis.core.RedisTemplate
@@ -34,6 +35,8 @@ class NotificationService(
     private val redisTemplate: RedisTemplate<String, String>,
     private val objectMapper: ObjectMapper,
     private val presenceHandler: PresenceHandler,
+    private val userRevocationService: UserRevocationService,
+    private val sessionRegistry: SessionRegistry,
 ) {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onInviteSent(event: InviteSentEvent) {
@@ -141,5 +144,7 @@ class NotificationService(
         ))
 
         redisTemplate.convertAndSend(PresenceKeys.userChannel(event.userId), payload)
+        userRevocationService.revokeBanned(event.userId)
+        sessionRegistry.closeUserSessions(event.userId)
     }
 }

--- a/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
@@ -91,7 +91,7 @@ class NotificationService(
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onUserJoinedRoom(event: UserJoinedRoomEvent) {
         val payload = objectMapper.writeValueAsString(
-            WsChat(type = "JOIN", username = event.username, content = "", timestamp = Instant.now())
+            WsChat(type = "JOIN", username = event.username, content = "", userId = event.userId, timestamp = Instant.now())
         )
         redisTemplate.convertAndSend(PresenceKeys.roomChannel(event.roomId), payload)
 

--- a/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
@@ -1,5 +1,7 @@
 package com.blikeng.chatapp.services
 
+import com.blikeng.chatapp.events.UserLeftRoomEvent
+import com.blikeng.chatapp.dtos.messaging.RabbitMessageDTO
 import com.blikeng.chatapp.dtos.room.RoomAction
 import com.blikeng.chatapp.dtos.websocket.WsBannedEvent
 import com.blikeng.chatapp.dtos.websocket.WsChat
@@ -23,6 +25,7 @@ import com.blikeng.chatapp.messaging.redis.PresenceHandler
 import com.blikeng.chatapp.messaging.redis.PresenceKeys
 import com.blikeng.chatapp.websocket.SessionRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.amqp.rabbit.core.RabbitTemplate
 import java.time.Instant
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
@@ -37,6 +40,7 @@ class NotificationService(
     private val presenceHandler: PresenceHandler,
     private val userRevocationService: UserRevocationService,
     private val sessionRegistry: SessionRegistry,
+    private val rabbitTemplate: RabbitTemplate,
 ) {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onInviteSent(event: InviteSentEvent) {
@@ -91,7 +95,7 @@ class NotificationService(
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onUserJoinedRoom(event: UserJoinedRoomEvent) {
         val payload = objectMapper.writeValueAsString(
-            WsChat(type = "JOIN", username = event.username, content = "", userId = event.userId, timestamp = Instant.now())
+            WsChat(type = "JOIN", username = "Server", content = "${event.username} joined the room!", userId = event.userId, timestamp = Instant.now())
         )
         redisTemplate.convertAndSend(PresenceKeys.roomChannel(event.roomId), payload)
 
@@ -99,6 +103,41 @@ class NotificationService(
             WsRoomPresence(roomId = event.roomId, userId = event.userId, online = presenceHandler.isUserOnline(event.userId))
         )
         redisTemplate.convertAndSend(PresenceKeys.roomChannel(event.roomId), presencePayload)
+
+        val rabbitMessage = RabbitMessageDTO(
+            id = UUID.randomUUID(),
+            username = "Server",
+            roomId = event.roomId,
+            userId = event.userId,
+            message = "${event.username} joined the room!"
+        )
+        val rabbitJson = objectMapper.writeValueAsString(rabbitMessage)
+        redisTemplate.opsForList().rightPush("chat.peek.${event.roomId}", rabbitJson)
+        rabbitTemplate.convertAndSend("chat.buffer", rabbitMessage)
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onUserLeftRoom(event: UserLeftRoomEvent) {
+        val payload = objectMapper.writeValueAsString(
+            WsChat(type = "LEAVE", username = "Server", content = "${event.username} left the room.", userId = event.userId, timestamp = Instant.now())
+        )
+        redisTemplate.convertAndSend(PresenceKeys.roomChannel(event.roomId), payload)
+
+        val presencePayload = objectMapper.writeValueAsString(
+            WsRoomPresence(roomId = event.roomId, userId = event.userId, online = presenceHandler.isUserOnline(event.userId))
+        )
+        redisTemplate.convertAndSend(PresenceKeys.roomChannel(event.roomId), presencePayload)
+
+        val rabbitMessage = RabbitMessageDTO(
+            id = UUID.randomUUID(),
+            username = "Server",
+            roomId = event.roomId,
+            userId = event.userId,
+            message = "${event.username} left the room."
+        )
+        val rabbitJson = objectMapper.writeValueAsString(rabbitMessage)
+        redisTemplate.opsForList().rightPush("chat.peek.${event.roomId}", rabbitJson)
+        rabbitTemplate.convertAndSend("chat.buffer", rabbitMessage)
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
@@ -93,50 +93,26 @@ class NotificationService(
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun onUserJoinedRoom(event: UserJoinedRoomEvent) {
-        val payload = objectMapper.writeValueAsString(
-            WsChat(type = "JOIN", username = "Server", content = "${event.username} joined the room!", userId = event.userId, timestamp = Instant.now())
-        )
-        redisTemplate.convertAndSend(PresenceKeys.roomChannel(event.roomId), payload)
-
-        val presencePayload = objectMapper.writeValueAsString(
-            WsRoomPresence(roomId = event.roomId, userId = event.userId, online = presenceHandler.isUserOnline(event.userId))
-        )
-        redisTemplate.convertAndSend(PresenceKeys.roomChannel(event.roomId), presencePayload)
-
-        val rabbitMessage = RabbitMessageDTO(
-            id = UUID.randomUUID(),
-            username = "Server",
-            roomId = event.roomId,
-            userId = event.userId,
-            message = "${event.username} joined the room!"
-        )
-        val rabbitJson = objectMapper.writeValueAsString(rabbitMessage)
-        redisTemplate.opsForList().rightPush("chat.peek.${event.roomId}", rabbitJson)
-        rabbitTemplate.convertAndSend("chat.buffer", rabbitMessage)
-    }
+    fun onUserJoinedRoom(event: UserJoinedRoomEvent) =
+        broadcastMembershipChange(event.roomId, event.userId, event.username, "JOIN", "${event.username} joined the room!")
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun onUserLeftRoom(event: UserLeftRoomEvent) {
-        val payload = objectMapper.writeValueAsString(
-            WsChat(type = "LEAVE", username = "Server", content = "${event.username} left the room.", userId = event.userId, timestamp = Instant.now())
+    fun onUserLeftRoom(event: UserLeftRoomEvent) =
+        broadcastMembershipChange(event.roomId, event.userId, event.username, "LEAVE", "${event.username} left the room.")
+
+    private fun broadcastMembershipChange(roomId: UUID, userId: UUID, username: String, type: String, message: String) {
+        val chatPayload = objectMapper.writeValueAsString(
+            WsChat(type = type, username = "Server", content = message, userId = userId, timestamp = Instant.now())
         )
-        redisTemplate.convertAndSend(PresenceKeys.roomChannel(event.roomId), payload)
+        redisTemplate.convertAndSend(PresenceKeys.roomChannel(roomId), chatPayload)
 
         val presencePayload = objectMapper.writeValueAsString(
-            WsRoomPresence(roomId = event.roomId, userId = event.userId, online = presenceHandler.isUserOnline(event.userId))
+            WsRoomPresence(roomId = roomId, userId = userId, online = presenceHandler.isUserOnline(userId))
         )
-        redisTemplate.convertAndSend(PresenceKeys.roomChannel(event.roomId), presencePayload)
+        redisTemplate.convertAndSend(PresenceKeys.roomChannel(roomId), presencePayload)
 
-        val rabbitMessage = RabbitMessageDTO(
-            id = UUID.randomUUID(),
-            username = "Server",
-            roomId = event.roomId,
-            userId = event.userId,
-            message = "${event.username} left the room."
-        )
-        val rabbitJson = objectMapper.writeValueAsString(rabbitMessage)
-        redisTemplate.opsForList().rightPush("chat.peek.${event.roomId}", rabbitJson)
+        val rabbitMessage = RabbitMessageDTO(id = UUID.randomUUID(), username = "Server", roomId = roomId, userId = userId, message = message)
+        redisTemplate.opsForList().rightPush("chat.peek.$roomId", objectMapper.writeValueAsString(rabbitMessage))
         rabbitTemplate.convertAndSend("chat.buffer", rabbitMessage)
     }
 

--- a/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/NotificationService.kt
@@ -1,6 +1,7 @@
 package com.blikeng.chatapp.services
 
 import com.blikeng.chatapp.dtos.room.RoomAction
+import com.blikeng.chatapp.dtos.websocket.WsBannedEvent
 import com.blikeng.chatapp.dtos.websocket.WsChat
 import com.blikeng.chatapp.dtos.websocket.WsFriendAdded
 import com.blikeng.chatapp.dtos.websocket.WsFriendPresence
@@ -9,12 +10,15 @@ import com.blikeng.chatapp.dtos.websocket.WsInviteReceived
 import com.blikeng.chatapp.dtos.websocket.WsRoomAction
 import com.blikeng.chatapp.dtos.websocket.WsRoomDeleted
 import com.blikeng.chatapp.dtos.websocket.WsRoomPresence
+import com.blikeng.chatapp.dtos.websocket.WsUserRoleChanged
 import com.blikeng.chatapp.entities.InviteType
 import com.blikeng.chatapp.events.InviteAcceptedEvent
 import com.blikeng.chatapp.events.InviteSentEvent
 import com.blikeng.chatapp.events.RoomDeletedEvent
+import com.blikeng.chatapp.events.UserBannedEvent
 import com.blikeng.chatapp.events.UserJoinedRoomEvent
 import com.blikeng.chatapp.events.UserRemovedEvent
+import com.blikeng.chatapp.events.UserRoleChangedEvent
 import com.blikeng.chatapp.messaging.redis.PresenceHandler
 import com.blikeng.chatapp.messaging.redis.PresenceKeys
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -115,5 +119,27 @@ class NotificationService(
         event.memberIds.forEach { memberId ->
             redisTemplate.convertAndSend(PresenceKeys.userChannel(memberId), payload)
         }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onUserRoleChanges(event: UserRoleChangedEvent) {
+        val payload = objectMapper.writeValueAsString(WsUserRoleChanged(
+            userId = event.userId,
+            byUsername = event.byUsername,
+            newRole = event.newRole,
+            action = event.action
+        ))
+
+        redisTemplate.convertAndSend(PresenceKeys.userChannel(event.userId), payload)
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onUserBanned(event: UserBannedEvent){
+        val payload = objectMapper.writeValueAsString(WsBannedEvent(
+            byUsername = event.byUsername,
+            reason = event.reason,
+        ))
+
+        redisTemplate.convertAndSend(PresenceKeys.userChannel(event.userId), payload)
     }
 }

--- a/src/main/kotlin/com/blikeng/chatapp/services/RoomService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/RoomService.kt
@@ -76,7 +76,7 @@ class RoomService(
         val userId = getId()
         val key = "user:$userId:rooms"
 
-        val cached = redisTemplate.opsForValue().get(key)
+        val cached = redisTemplate.opsForValue()[key]
         if (cached != null) return objectMapper.readValue(cached, roomListType)
 
         val joinedRooms = roomRepository.findRoomsForUser(userId)

--- a/src/main/kotlin/com/blikeng/chatapp/services/RoomService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/RoomService.kt
@@ -1,5 +1,6 @@
 package com.blikeng.chatapp.services
 
+import com.blikeng.chatapp.events.UserLeftRoomEvent
 import com.blikeng.chatapp.dtos.UserIdDTO
 import com.blikeng.chatapp.dtos.room.AdministrationDTO
 import com.blikeng.chatapp.dtos.room.ChangeRoleDTO
@@ -140,15 +141,17 @@ class RoomService(
     fun joinRoom(id: UUID, roomId: UUID) {
         val user = userService.getUserById(id) ?: throw InvalidUserException()
         val userRoom = UserRoomEntity(UserRoomId(id, roomId), RoomRole.MEMBER, RoomType.GROUP)
+
         userRoomRepository.save(userRoom)
         bustRoomsCache(id)
         bustRoomMembersCache(roomId)
+
         eventPublisher.publishEvent(UserJoinedRoomEvent(userId = id, username = user.username, roomId = roomId))
     }
 
     @Transactional
     fun leaveRoom(roomId: String?){
-        val userId = getId()
+        val user = userService.getUserById(getId()) ?: throw InvalidUserException()
 
         val roomUUID = try {
             UUID.fromString(roomId)
@@ -156,14 +159,16 @@ class RoomService(
             throw InvalidUUIDException()
         }
 
-        val existed = userRoomRepository.existsByIdUserIdAndIdRoomId(userId, roomUUID)
+        val existed = userRoomRepository.existsByIdUserIdAndIdRoomId(user.id, roomUUID)
         if (!existed) {
             throw RoomNotFoundException()
         }
 
-        userRoomRepository.deleteByIdUserIdAndIdRoomId(userId, roomUUID)
-        bustRoomsCache(userId)
+        userRoomRepository.deleteByIdUserIdAndIdRoomId(user.id, roomUUID)
+        bustRoomsCache(user.id)
         bustRoomMembersCache(roomUUID)
+
+        eventPublisher.publishEvent(UserLeftRoomEvent(userId = user.id, username = user.username, roomId = roomUUID))
     }
 
     // ==========================

--- a/src/main/kotlin/com/blikeng/chatapp/services/RoomService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/RoomService.kt
@@ -15,6 +15,7 @@ import com.blikeng.chatapp.events.RoomDeletedEvent
 import com.blikeng.chatapp.events.UserJoinedRoomEvent
 import com.blikeng.chatapp.events.UserRemovedEvent
 
+import com.blikeng.chatapp.messaging.redis.PresenceKeys
 import com.blikeng.chatapp.repositories.RoomRepository
 import com.blikeng.chatapp.repositories.UserRoomRepository
 import com.blikeng.chatapp.security.auth.getId
@@ -49,6 +50,9 @@ class RoomService(
 
     private fun bustRoomsCache(vararg userIds: UUID) =
         userIds.forEach { redisTemplate.delete("user:$it:rooms") }
+
+    private fun bustRoomMembersCache(roomId: UUID) =
+        redisTemplate.delete(PresenceKeys.roomMembersKey(roomId))
     // ==========================
     // Room creation and retrieval
     // ==========================
@@ -138,6 +142,7 @@ class RoomService(
         val userRoom = UserRoomEntity(UserRoomId(id, roomId), RoomRole.MEMBER, RoomType.GROUP)
         userRoomRepository.save(userRoom)
         bustRoomsCache(id)
+        bustRoomMembersCache(roomId)
         eventPublisher.publishEvent(UserJoinedRoomEvent(userId = id, username = user.username, roomId = roomId))
     }
 
@@ -158,6 +163,7 @@ class RoomService(
 
         userRoomRepository.deleteByIdUserIdAndIdRoomId(userId, roomUUID)
         bustRoomsCache(userId)
+        bustRoomMembersCache(roomUUID)
     }
 
     // ==========================
@@ -211,6 +217,7 @@ class RoomService(
         val room = roomRepository.findById(roomUUID).orElseThrow { RoomNotFoundException() }
         roomRepository.delete(room)
         bustRoomsCache(*memberIds.toTypedArray())
+        bustRoomMembersCache(roomUUID)
 
         eventPublisher.publishEvent(RoomDeletedEvent(roomUUID, room.name, memberIds))
     }
@@ -268,6 +275,7 @@ class RoomService(
 
         userRoomRepository.deleteByIdUserIdAndIdRoomId(targetId, roomId)
         bustRoomsCache(targetId)
+        bustRoomMembersCache(roomId)
 
         if (action == RoomAction.BAN) bannedUserService.banUser(targetId, roomId)
 

--- a/src/main/kotlin/com/blikeng/chatapp/services/UserRevocationService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/UserRevocationService.kt
@@ -20,4 +20,16 @@ class UserRevocationService(
     fun isRevoked(userId: UUID): Boolean {
         return redisTemplate.hasKey("revoked_user:$userId") == true
     }
+
+    fun revokeBanned(userId: UUID) {
+        redisTemplate.opsForValue().set("banned_user:$userId", "1", Duration.ofHours(24))
+    }
+
+    fun isBanned(userId: UUID): Boolean {
+        return redisTemplate.hasKey("banned_user:$userId") == true
+    }
+
+    fun unRevokeBanned(userId: UUID) {
+        redisTemplate.delete("banned_user:$userId")
+    }
 }

--- a/src/main/kotlin/com/blikeng/chatapp/services/UserService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/UserService.kt
@@ -1,5 +1,6 @@
 package com.blikeng.chatapp.services
 
+import com.blikeng.chatapp.dtos.auth.AuthDTO
 import com.blikeng.chatapp.dtos.user.ChangeUserDTO
 import com.blikeng.chatapp.dtos.user.EditPasswordDTO
 import com.blikeng.chatapp.dtos.user.UserDTO
@@ -15,6 +16,7 @@ import com.blikeng.chatapp.security.auth.PasswordService
 import com.blikeng.chatapp.security.auth.getId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import tools.jackson.databind.ObjectMapper
 import java.util.*
 
 
@@ -28,6 +30,7 @@ class UserService(
     private val passwordService: PasswordService,
     private val roomRepository: RoomRepository,
     private val userRevocationService: UserRevocationService,
+    private val objectMapper: ObjectMapper,
 ) {
     fun getUserById(id: UUID): UserEntity? {
         return userRepository.findById(id).orElse(null)
@@ -50,11 +53,15 @@ class UserService(
         )
     }
 
-    fun getRole(): UserRole {
+    fun authenticate(): AuthDTO {
         val id = getId()
         val user = getUserById(id) ?: throw InvalidUserException()
 
-        return user.role
+        return AuthDTO(
+            userId = id,
+            username = user.username,
+            userRole = user.role,
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/com/blikeng/chatapp/services/UserService.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/services/UserService.kt
@@ -11,12 +11,10 @@ import com.blikeng.chatapp.errors.ShortPasswordException
 import com.blikeng.chatapp.errors.WrongPasswordException
 import com.blikeng.chatapp.repositories.RoomRepository
 import com.blikeng.chatapp.repositories.UserRepository
-import com.blikeng.chatapp.security.UserRole
 import com.blikeng.chatapp.security.auth.PasswordService
 import com.blikeng.chatapp.security.auth.getId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import tools.jackson.databind.ObjectMapper
 import java.util.*
 
 
@@ -30,7 +28,6 @@ class UserService(
     private val passwordService: PasswordService,
     private val roomRepository: RoomRepository,
     private val userRevocationService: UserRevocationService,
-    private val objectMapper: ObjectMapper,
 ) {
     fun getUserById(id: UUID): UserEntity? {
         return userRepository.findById(id).orElse(null)

--- a/src/main/kotlin/com/blikeng/chatapp/websocket/ChatWebSocketHandler.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/websocket/ChatWebSocketHandler.kt
@@ -126,13 +126,15 @@ class ChatWebSocketHandler(
 
     private fun handleJoin(session: WebSocketSession, json: JsonNode) {
         val roomId = getRoomId(json)
-        val userId = getUserId(session)
-        val username = getUsername(session)
 
         chatService.joinRoom(roomId, session)
+    }
 
-        val message = ReceivedMessage(roomId, userId, "$username joined the room", "JOIN")
-        chatService.broadcast(roomId, userId, message, username)
+    private fun handleLeave(session: WebSocketSession, json: JsonNode) {
+        val roomId = getRoomId(json)
+
+        lastPing.remove(session.id)
+        chatService.leaveRoom(roomId, session)
     }
 
     private fun handleChatMessage(session: WebSocketSession, json: JsonNode) {
@@ -153,17 +155,6 @@ class ChatWebSocketHandler(
         )
 
         if (!checkRateLimit(userId, session)) return
-        chatService.broadcast(roomId, userId, message, username)
-    }
-
-    private fun handleLeave(session: WebSocketSession, json: JsonNode) {
-        val roomId = getRoomId(json)
-        val userId = getUserId(session)
-        val username = getUsername(session)
-
-        lastPing.remove(session.id)
-        chatService.leaveRoom(roomId, session)
-        val message = ReceivedMessage(roomId, userId, "$username left the room", "LEAVE")
         chatService.broadcast(roomId, userId, message, username)
     }
 

--- a/src/main/kotlin/com/blikeng/chatapp/websocket/ChatWebSocketHandler.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/websocket/ChatWebSocketHandler.kt
@@ -73,6 +73,9 @@ class ChatWebSocketHandler(
                     session.sendMessage(TextMessage("pong"))
                 }
                 MessageType.SYNC -> sessionRegistry.sendSnapshots(getUserId(session), session)
+                MessageType.TYPING -> {
+                    handleTyping(session, json)
+                }
             }
         } catch (e: Exception) {
             sendWsError(session, e)
@@ -80,7 +83,7 @@ class ChatWebSocketHandler(
     }
 
     enum class MessageType {
-        MESSAGE, JOIN, LEAVE, PING, SYNC
+        MESSAGE, JOIN, LEAVE, PING, SYNC, TYPING
     }
 
     // ==========================
@@ -129,7 +132,7 @@ class ChatWebSocketHandler(
         chatService.joinRoom(roomId, session)
 
         val message = ReceivedMessage(roomId, userId, "$username joined the room", "JOIN")
-        chatService.broadcast(roomId, message, username)
+        chatService.broadcast(roomId, userId, message, username)
     }
 
     private fun handleChatMessage(session: WebSocketSession, json: JsonNode) {
@@ -150,7 +153,7 @@ class ChatWebSocketHandler(
         )
 
         if (!checkRateLimit(userId, session)) return
-        chatService.broadcast(roomId, message, username)
+        chatService.broadcast(roomId, userId, message, username)
     }
 
     private fun handleLeave(session: WebSocketSession, json: JsonNode) {
@@ -161,7 +164,15 @@ class ChatWebSocketHandler(
         lastPing.remove(session.id)
         chatService.leaveRoom(roomId, session)
         val message = ReceivedMessage(roomId, userId, "$username left the room", "LEAVE")
-        chatService.broadcast(roomId, message, username)
+        chatService.broadcast(roomId, userId, message, username)
+    }
+
+    private fun handleTyping(session: WebSocketSession, json: JsonNode) {
+        val roomId = getRoomId(json)
+        val userId = getUserId(session)
+        val username = getUsername(session)
+
+        chatService.notifyTyping(roomId, userId, username)
     }
 
     private fun parseMessageType(json: JsonNode): MessageType {

--- a/src/main/kotlin/com/blikeng/chatapp/websocket/SessionRegistry.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/websocket/SessionRegistry.kt
@@ -99,4 +99,12 @@ class SessionRegistry(
     }
 
     fun getSessionById(sessionId: String): WebSocketSession? = sessionIndex[sessionId]
+
+    fun closeUserSessions(userId: UUID) {
+        users[userId]?.forEach { session ->
+            if (session.isOpen) {
+                try { session.close() } catch (_: IOException) {}
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/blikeng/chatapp/websocket/SessionRegistry.kt
+++ b/src/main/kotlin/com/blikeng/chatapp/websocket/SessionRegistry.kt
@@ -103,7 +103,9 @@ class SessionRegistry(
     fun closeUserSessions(userId: UUID) {
         users[userId]?.forEach { session ->
             if (session.isOpen) {
-                try { session.close() } catch (_: IOException) {}
+                try { session.close() } catch (_: IOException) {
+                    // Session closed before we could close it. Ignore.
+                }
             }
         }
     }

--- a/src/test/kotlin/com/blikeng/chatapp/controllerTests/AdministrationControllerTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/controllerTests/AdministrationControllerTests.kt
@@ -22,7 +22,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.*
 import java.time.Instant
 import java.util.*
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @WebMvcTest(
     controllers = [AdministrationController::class],

--- a/src/test/kotlin/com/blikeng/chatapp/controllerTests/AuthControllerTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/controllerTests/AuthControllerTests.kt
@@ -1,9 +1,11 @@
 package com.blikeng.chatapp.controllerTests
 
 import com.blikeng.chatapp.controllers.AuthController
+import com.blikeng.chatapp.dtos.auth.AuthDTO
 import com.blikeng.chatapp.errors.ErrorMessages
 import com.blikeng.chatapp.errors.InvalidCredentialsException
 import com.blikeng.chatapp.errors.UsernameAlreadyExistsException
+import com.blikeng.chatapp.security.UserRole
 import com.blikeng.chatapp.security.auth.JwtAuthFilter
 import com.blikeng.chatapp.security.ratelimit.RateLimitService
 import com.blikeng.chatapp.services.AuthService
@@ -23,6 +25,7 @@ import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 @WebMvcTest(
     controllers = [AuthController::class],
@@ -138,7 +141,7 @@ class AuthControllerTests {
     // ==========================
     @Test
     fun shouldReturnOkForAuthEndpoint() {
-        every { userService.getRole() } returns com.blikeng.chatapp.security.UserRole.USER
+        every { userService.authenticate() } returns AuthDTO(UUID.randomUUID(), "", UserRole.USER)
 
         mockMvc.get("/api/auth") {
         }

--- a/src/test/kotlin/com/blikeng/chatapp/controllerTests/AuthControllerTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/controllerTests/AuthControllerTests.kt
@@ -5,7 +5,6 @@ import com.blikeng.chatapp.errors.ErrorMessages
 import com.blikeng.chatapp.errors.InvalidCredentialsException
 import com.blikeng.chatapp.errors.UsernameAlreadyExistsException
 import com.blikeng.chatapp.security.auth.JwtAuthFilter
-import com.blikeng.chatapp.dtos.user.UserDTO
 import com.blikeng.chatapp.security.ratelimit.RateLimitService
 import com.blikeng.chatapp.services.AuthService
 import com.blikeng.chatapp.services.UserService
@@ -23,7 +22,7 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @WebMvcTest(
     controllers = [AuthController::class],

--- a/src/test/kotlin/com/blikeng/chatapp/controllerTests/ChatsControllerTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/controllerTests/ChatsControllerTests.kt
@@ -19,7 +19,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import java.time.Instant
 import java.util.*
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @WebMvcTest(
     controllers = [ChatsController::class],

--- a/src/test/kotlin/com/blikeng/chatapp/controllerTests/InvitesControllerTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/controllerTests/InvitesControllerTests.kt
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import java.time.Instant
 import java.util.*
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @WebMvcTest(
     controllers = [InvitesController::class],

--- a/src/test/kotlin/com/blikeng/chatapp/controllerTests/RoomControllerTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/controllerTests/RoomControllerTests.kt
@@ -9,7 +9,6 @@ import com.blikeng.chatapp.entities.RoomType
 import com.blikeng.chatapp.errors.InvalidRoomNameException
 import com.blikeng.chatapp.errors.InvalidTokenException
 import com.blikeng.chatapp.errors.NotPermittedException
-import com.blikeng.chatapp.errors.RoomNotFoundException
 import com.blikeng.chatapp.security.auth.JwtAuthFilter
 import com.blikeng.chatapp.security.ratelimit.RateLimitService
 import com.blikeng.chatapp.services.RoomService
@@ -25,7 +24,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import java.util.*
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @WebMvcTest(
     controllers = [RoomController::class],

--- a/src/test/kotlin/com/blikeng/chatapp/controllerTests/UserControllerTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/controllerTests/UserControllerTests.kt
@@ -20,7 +20,7 @@ import org.springframework.test.web.servlet.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import java.time.Instant
 import java.util.UUID
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @WebMvcTest(
     controllers = [UserController::class],

--- a/src/test/kotlin/com/blikeng/chatapp/e2e/E2ETests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/e2e/E2ETests.kt
@@ -720,7 +720,8 @@ class E2ETests : ContainerBase() {
         }
             .andExpect { status { isOk() } }
             .andExpect {
-                jsonPath("$[0].message") { value("encrypted hello from user1") }
+                jsonPath("$[0].message") { value("username joined the room!") }
+                jsonPath("$[1].message") { value("encrypted hello from user1") }
             }
     }
 

--- a/src/test/kotlin/com/blikeng/chatapp/messagingTests/LocalBroadcasterTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/messagingTests/LocalBroadcasterTests.kt
@@ -6,7 +6,6 @@ import com.blikeng.chatapp.websocket.SessionRegistry
 import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
-import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -50,7 +49,7 @@ class LocalBroadcasterTests {
         every { session2.isOpen } returns true
         every { session1.sendMessage(any()) } just Runs
         every { session2.sendMessage(any()) } just Runs
-        every { chatService.rooms } returns ConcurrentHashMap<UUID, MutableSet<WebSocketSession>>().apply {
+        every { chatService.sessionsInRooms } returns ConcurrentHashMap<UUID, MutableSet<WebSocketSession>>().apply {
             put(roomId, CopyOnWriteArraySet(listOf(session1, session2)))
         }
 
@@ -66,7 +65,7 @@ class LocalBroadcasterTests {
         val session = mockk<WebSocketSession>()
 
         every { session.isOpen } returns false
-        every { chatService.rooms } returns ConcurrentHashMap<UUID, MutableSet<WebSocketSession>>().apply {
+        every { chatService.sessionsInRooms } returns ConcurrentHashMap<UUID, MutableSet<WebSocketSession>>().apply {
             put(roomId, CopyOnWriteArraySet(listOf(session)))
         }
 
@@ -91,7 +90,7 @@ class LocalBroadcasterTests {
         val rooms = ConcurrentHashMap<UUID, MutableSet<WebSocketSession>>()
         rooms[roomId] = CopyOnWriteArraySet(listOf(session))
 
-        every { chatService.rooms } returns rooms
+        every { chatService.sessionsInRooms } returns rooms
         every { chatService.leaveRoom(any(), any()) } just Runs
 
         broadcaster.broadcastRaw(roomId, "hello")
@@ -105,7 +104,7 @@ class LocalBroadcasterTests {
 
         val rooms = ConcurrentHashMap<UUID, MutableSet<WebSocketSession>>()
 
-        every { chatService.rooms } returns rooms
+        every { chatService.sessionsInRooms } returns rooms
 
         assertDoesNotThrow {
             broadcaster.broadcastRaw(roomId, "hello")

--- a/src/test/kotlin/com/blikeng/chatapp/messagingTests/PresenceHandlerTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/messagingTests/PresenceHandlerTests.kt
@@ -17,9 +17,9 @@ import org.springframework.data.redis.core.Cursor
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ValueOperations
 import java.util.*
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 
 @ExtendWith(MockKExtension::class)
 class PresenceHandlerTests {

--- a/src/test/kotlin/com/blikeng/chatapp/messagingTests/RedisMessageSubscriberTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/messagingTests/RedisMessageSubscriberTests.kt
@@ -13,7 +13,7 @@ import org.springframework.data.redis.connection.MessageListener
 import org.springframework.data.redis.listener.PatternTopic
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import java.util.*
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @ExtendWith(MockKExtension::class)
 class RedisMessageSubscriberTests {

--- a/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/AuthHandshakeInterceptorTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/AuthHandshakeInterceptorTests.kt
@@ -59,6 +59,7 @@ class AuthHandshakeInterceptorTests {
             role = "USER"
         )
         every { userRevocationService.isRevoked(userId) } returns false
+        every { userRevocationService.isBanned(userId) } returns false
 
         val servletRequest = mockk<HttpServletRequest> {
             every { cookies } returns cookiesList
@@ -184,6 +185,32 @@ class AuthHandshakeInterceptorTests {
             role = "USER"
         )
         every { userRevocationService.isRevoked(userId) } returns true
+
+        val servletRequest = mockk<HttpServletRequest> {
+            every { cookies } returns cookiesList
+        }
+
+        val request = ServletServerHttpRequest(servletRequest)
+        val attributes = mutableMapOf<String, Any>()
+
+        val result = interceptor.beforeHandshake(request, mockk(relaxed = true), mockk(relaxed = true), attributes)
+
+        assertFalse(result)
+        assertTrue(attributes.isEmpty())
+    }
+
+    @Test
+    fun shouldFailWhenUserIsBanned() {
+        val cookiesList: Array<Cookie> = arrayOf(Cookie("AUTH", "token"))
+        val userId = UUID.randomUUID()
+
+        every { jwtService.validateToken("token") } returns JwtService.JwtPrincipal(
+            username = "user",
+            userId = userId,
+            role = "USER"
+        )
+        every { userRevocationService.isRevoked(userId) } returns false
+        every { userRevocationService.isBanned(userId) } returns true
 
         val servletRequest = mockk<HttpServletRequest> {
             every { cookies } returns cookiesList

--- a/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/AuthHandshakeInterceptorTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/AuthHandshakeInterceptorTests.kt
@@ -18,10 +18,10 @@ import org.springframework.http.server.ServerHttpResponse
 import org.springframework.http.server.ServletServerHttpRequest
 import org.springframework.web.socket.WebSocketHandler
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 
 @ExtendWith(MockKExtension::class)
 class AuthHandshakeInterceptorTests {

--- a/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/JwtAuthFilterTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/JwtAuthFilterTests.kt
@@ -3,6 +3,7 @@ package com.blikeng.chatapp.securityTests.auth
 import com.blikeng.chatapp.security.auth.JwtAuthFilter
 import com.blikeng.chatapp.security.auth.JwtService
 import com.blikeng.chatapp.services.UserRevocationService
+import org.springframework.core.env.Environment
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
@@ -32,7 +33,8 @@ class JwtAuthFilterTests {
     // ==========================
     private val jwtService = mockk<JwtService>()
     private val userRevocationService = mockk<UserRevocationService>()
-    private val filter = JwtAuthFilter(jwtService, userRevocationService)
+    private val environment = mockk<Environment>()
+    private val filter = JwtAuthFilter(jwtService, userRevocationService, environment)
 
     @BeforeEach
     fun setup() {
@@ -87,6 +89,7 @@ class JwtAuthFilterTests {
             role = "ADMIN"
         )
         every { userRevocationService.isRevoked(userId) } returns false
+        every { userRevocationService.isBanned(userId) } returns false
 
         val req = MockHttpServletRequest()
         req.setCookies(Cookie("AUTH", "good"))
@@ -96,7 +99,9 @@ class JwtAuthFilterTests {
 
         filter.doFilter(req, res, chain)
 
-        val auth = SecurityContextHolder.getContext().authentication
+        val authTemp = SecurityContextHolder.getContext().authentication
+        val auth = requireNotNull(authTemp)
+
         assertNotNull(auth)
         assertEquals(userId, auth.principal)
         assertEquals("u", auth.credentials)
@@ -157,6 +162,29 @@ class JwtAuthFilterTests {
             role = "USER"
         )
         every { userRevocationService.isRevoked(userId) } returns true
+
+        val req = MockHttpServletRequest()
+        req.setCookies(Cookie("AUTH", "good"))
+
+        val res = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(req, res, chain)
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+    }
+
+    @Test
+    fun shouldNotAuthenticateBannedUser() {
+        val userId = UUID.randomUUID()
+        every { jwtService.validateToken("good") } returns JwtService.JwtPrincipal(
+            username = "u",
+            userId = userId,
+            role = "USER"
+        )
+        every { userRevocationService.isRevoked(userId) } returns false
+        every { userRevocationService.isBanned(userId) } returns true
+        every { environment.activeProfiles } returns arrayOf("test")
 
         val req = MockHttpServletRequest()
         req.setCookies(Cookie("AUTH", "good"))

--- a/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/JwtAuthFilterTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/JwtAuthFilterTests.kt
@@ -17,9 +17,9 @@ import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 
 class JwtAuthFilterTests {
     // ==========================

--- a/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/JwtServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/JwtServiceTests.kt
@@ -5,8 +5,8 @@ import com.blikeng.chatapp.security.auth.JwtService
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.assertNull
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class JwtServiceTests {
     // ==========================
@@ -53,7 +53,7 @@ class JwtServiceTests {
     fun shouldThrowWhenSecretIsTooShort() {
         val secret = "short-secret"
 
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertThrows<IllegalArgumentException> {
             JwtService(secret)
         }
 

--- a/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/PasswordServiceTest.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/PasswordServiceTest.kt
@@ -2,7 +2,7 @@ package com.blikeng.chatapp.securityTests.auth
 
 import com.blikeng.chatapp.security.auth.PasswordService
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 class PasswordServiceTest {
     // ==========================

--- a/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/SecurityIntegrationTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/securityTests/auth/SecurityIntegrationTests.kt
@@ -9,7 +9,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/kotlin/com/blikeng/chatapp/securityTests/crypto/ChatEncryptTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/securityTests/crypto/ChatEncryptTests.kt
@@ -3,10 +3,9 @@ package com.blikeng.chatapp.securityTests.crypto
 import com.blikeng.chatapp.config.configureAad
 import com.blikeng.chatapp.security.crypto.ChatEncrypt
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFails
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 class ChatEncryptTests {
     // ==========================
@@ -47,7 +46,7 @@ class ChatEncryptTests {
 
         val encrypted = encrypt.encrypt(plaintext, aad)
 
-        assertFails {
+        assertThrows<Exception> {
             encrypt.decrypt(encrypted.ciphertext, byteArrayOf(), aad)
         }
     }
@@ -61,7 +60,7 @@ class ChatEncryptTests {
 
         val encrypted = encrypt.encrypt(plaintext, aad1)
 
-        assertFails {
+        assertThrows<Exception> {
             encrypt.decrypt(encrypted.ciphertext, encrypted.nonce, aad2)
         }
     }
@@ -70,7 +69,7 @@ class ChatEncryptTests {
     fun shouldThrowOnInvalidBase64() {
         val keyB64 = "not base64"
 
-        assertFailsWith<IllegalArgumentException> {
+        assertThrows<IllegalArgumentException> {
             ChatEncrypt(keyB64)
         }
     }
@@ -80,7 +79,7 @@ class ChatEncryptTests {
         val raw16 = ByteArray(16) { 2 }
         val b64 = Base64.getEncoder().encodeToString(raw16)
 
-        assertFailsWith<IllegalArgumentException> {
+        assertThrows<IllegalArgumentException> {
             ChatEncrypt(b64)
         }
     }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/AdministrationServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/AdministrationServiceTests.kt
@@ -13,9 +13,11 @@ import com.blikeng.chatapp.repositories.UserBanRepository
 import com.blikeng.chatapp.repositories.UserRepository
 import com.blikeng.chatapp.security.UserRole
 import com.blikeng.chatapp.services.AdministrationService
+import com.blikeng.chatapp.services.UserRevocationService
 import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.extension.ExtendWith
@@ -28,6 +30,7 @@ import java.util.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
+import org.springframework.context.ApplicationEventPublisher
 
 @ExtendWith(MockKExtension::class)
 class AdministrationServiceTests {
@@ -43,6 +46,8 @@ class AdministrationServiceTests {
 
     @MockK private lateinit var userRepository: UserRepository
     @MockK private lateinit var userBanRepository: UserBanRepository
+    @RelaxedMockK private lateinit var eventPublisher: ApplicationEventPublisher
+    @MockK private lateinit var userRevocationService: UserRevocationService
 
     @InjectMockKs private lateinit var administrationService: AdministrationService
 
@@ -110,6 +115,7 @@ class AdministrationServiceTests {
         every { userRepository.findById(callerId) } returns Optional.of(caller)
         every { userRepository.findById(targetId) } returns Optional.of(target)
         every { userRepository.save(any()) } answers { firstArg() }
+        every { eventPublisher.publishEvent(any()) } just Runs
 
         administrationService.changeUserRole(UserRoleDTO(id = targetId.toString(), action = RoleAction.PROMOTE))
 
@@ -128,6 +134,7 @@ class AdministrationServiceTests {
         every { userRepository.findById(callerId) } returns Optional.of(caller)
         every { userRepository.findById(targetId) } returns Optional.of(target)
         every { userRepository.save(any()) } answers { firstArg() }
+        every { eventPublisher.publishEvent(any()) } just Runs
 
         administrationService.changeUserRole(UserRoleDTO(id = targetId.toString(), action = RoleAction.DEMOTE))
 
@@ -231,11 +238,34 @@ class AdministrationServiceTests {
         every { userRepository.findById(targetId) } returns Optional.of(target)
         every { userBanRepository.existsById(targetId) } returns false
         every { userBanRepository.save(any()) } answers { firstArg() }
+        every { eventPublisher.publishEvent(any()) } just Runs
 
         administrationService.banUser(BanUserDTO(id = targetId.toString(), reason = "rule violation"))
 
         verify(exactly = 1) {
             userBanRepository.save(match { it.userId == targetId && it.bannedBy == callerId && it.reason == "rule violation" })
+        }
+    }
+
+    @Test
+    fun shouldBanUserWithoutReason() {
+        val callerId = UUID.randomUUID()
+        val targetId = UUID.randomUUID()
+        authenticateAs(callerId)
+
+        val caller = UserEntity(id = callerId, username = "admin", password = "", role = UserRole.ADMIN)
+        val target = UserEntity(id = targetId, username = "alice", password = "", role = UserRole.USER)
+
+        every { userRepository.findById(callerId) } returns Optional.of(caller)
+        every { userRepository.findById(targetId) } returns Optional.of(target)
+        every { userBanRepository.existsById(targetId) } returns false
+        every { userBanRepository.save(any()) } answers { firstArg() }
+        every { eventPublisher.publishEvent(any()) } just Runs
+
+        administrationService.banUser(BanUserDTO(id = targetId.toString(), reason = null))
+
+        verify(exactly = 1) {
+            userBanRepository.save(match { it.userId == targetId && it.bannedBy == callerId && it.reason == null })
         }
     }
 
@@ -339,6 +369,7 @@ class AdministrationServiceTests {
         every { userBanRepository.findById(targetId) } returns Optional.of(ban)
         every { userRepository.findById(bannerId) } returns Optional.of(banner)
         every { userBanRepository.delete(ban) } just Runs
+        every { userRevocationService.unRevokeBanned(targetId) } just Runs
 
         administrationService.unbanUser(UserIdDTO(userId = targetId.toString()))
 
@@ -359,6 +390,7 @@ class AdministrationServiceTests {
         every { userBanRepository.findById(targetId) } returns Optional.of(ban)
         every { userRepository.findById(bannerId) } returns Optional.empty()
         every { userBanRepository.delete(ban) } just Runs
+        every { userRevocationService.unRevokeBanned(targetId) } just Runs
 
         administrationService.unbanUser(UserIdDTO(userId = targetId.toString()))
 

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/AdministrationServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/AdministrationServiceTests.kt
@@ -25,9 +25,9 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class AdministrationServiceTests {
@@ -91,7 +91,7 @@ class AdministrationServiceTests {
     fun shouldFailToGetUserWhenTargetNotFound() {
         every { userRepository.findByUsername(any()) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> { administrationService.getUser("alice") }
+        val exception = assertThrows<ApiException> { administrationService.getUser("alice") }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -146,7 +146,7 @@ class AdministrationServiceTests {
         every { userRepository.findById(callerId) } returns Optional.of(caller)
         every { userRepository.findById(targetId) } returns Optional.of(target)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.changeUserRole(UserRoleDTO(id = targetId.toString(), action = RoleAction.DEMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -164,7 +164,7 @@ class AdministrationServiceTests {
         every { userRepository.findById(callerId) } returns Optional.of(caller)
         every { userRepository.findById(targetId) } returns Optional.of(target)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.changeUserRole(UserRoleDTO(id = targetId.toString(), action = RoleAction.DEMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -179,7 +179,7 @@ class AdministrationServiceTests {
             UserEntity(id = callerId, username = "admin", password = "", role = UserRole.ADMIN)
         )
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.changeUserRole(UserRoleDTO(id = "not-a-uuid", action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -196,7 +196,7 @@ class AdministrationServiceTests {
         )
         every { userRepository.findById(targetId) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.changeUserRole(UserRoleDTO(id = targetId.toString(), action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -209,7 +209,7 @@ class AdministrationServiceTests {
 
         every { userRepository.findById(callerId) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.changeUserRole(UserRoleDTO(id = UUID.randomUUID().toString(), action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -252,7 +252,7 @@ class AdministrationServiceTests {
         every { userRepository.findById(targetId) } returns Optional.of(target)
         every { userBanRepository.existsById(targetId) } returns true
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.banUser(BanUserDTO(id = targetId.toString()))
         }
         assertEquals(HttpStatus.CONFLICT, exception.status)
@@ -270,7 +270,7 @@ class AdministrationServiceTests {
         every { userRepository.findById(callerId) } returns Optional.of(caller)
         every { userRepository.findById(targetId) } returns Optional.of(target)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.banUser(BanUserDTO(id = targetId.toString()))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -285,7 +285,7 @@ class AdministrationServiceTests {
             UserEntity(id = callerId, username = "admin", password = "", role = UserRole.ADMIN)
         )
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.banUser(BanUserDTO(id = "not-a-uuid"))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -302,7 +302,7 @@ class AdministrationServiceTests {
         )
         every { userRepository.findById(targetId) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.banUser(BanUserDTO(id = targetId.toString()))
         }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -315,7 +315,7 @@ class AdministrationServiceTests {
 
         every { userRepository.findById(callerId) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.banUser(BanUserDTO(id = UUID.randomUUID().toString()))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -376,7 +376,7 @@ class AdministrationServiceTests {
         )
         every { userBanRepository.findById(targetId) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.unbanUser(UserIdDTO(userId = targetId.toString()))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -397,7 +397,7 @@ class AdministrationServiceTests {
         every { userBanRepository.findById(targetId) } returns Optional.of(ban)
         every { userRepository.findById(bannerId) } returns Optional.of(banner)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.unbanUser(UserIdDTO(userId = targetId.toString()))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -412,7 +412,7 @@ class AdministrationServiceTests {
             UserEntity(id = callerId, username = "admin", password = "", role = UserRole.ADMIN)
         )
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.unbanUser(UserIdDTO(userId = "not-a-uuid"))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -425,7 +425,7 @@ class AdministrationServiceTests {
 
         every { userRepository.findById(callerId) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             administrationService.unbanUser(UserIdDTO(userId = UUID.randomUUID().toString()))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -483,7 +483,7 @@ class AdministrationServiceTests {
         val callerId = UUID.randomUUID()
         authenticateAs(callerId)
 
-        val exception = assertFailsWith<ApiException> { administrationService.getAllUserBans(0, 10) }
+        val exception = assertThrows<ApiException> { administrationService.getAllUserBans(0, 10) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -492,7 +492,7 @@ class AdministrationServiceTests {
         val callerId = UUID.randomUUID()
         authenticateAs(callerId)
 
-        val exception = assertFailsWith<ApiException> { administrationService.getAllUserBans(-1, 25) }
+        val exception = assertThrows<ApiException> { administrationService.getAllUserBans(-1, 25) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/AuthServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/AuthServiceTests.kt
@@ -13,9 +13,9 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.HttpStatus
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class AuthServiceTests {
@@ -48,7 +48,7 @@ class AuthServiceTests {
     fun shouldNotRegisterUserWithExistingUsername() {
         every { authRepository.existsByUsernameIgnoreCase(any()) } returns true
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             authService.registerUser("existinguser", "password123")
         }
 
@@ -60,7 +60,7 @@ class AuthServiceTests {
     fun shouldNotRegisterUserWithTooShortUsername() {
         every { authRepository.existsByUsernameIgnoreCase(any()) } returns false
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             authService.registerUser("u", "password")
         }
 
@@ -72,7 +72,7 @@ class AuthServiceTests {
     fun shouldNotRegisterUserWithTooShortPassword() {
         every { authRepository.existsByUsernameIgnoreCase(any()) } returns false
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             authService.registerUser("username", "p")
         }
 
@@ -82,7 +82,7 @@ class AuthServiceTests {
 
     @Test
     fun shouldNotRegisterUserWithTooLongUsername() {
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             authService.registerUser("a".repeat(33), "password123")
         }
 
@@ -92,7 +92,7 @@ class AuthServiceTests {
 
     @Test
     fun shouldNotRegisterUserWithTooLongPassword() {
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             authService.registerUser("username", "p".repeat(129))
         }
 
@@ -125,7 +125,7 @@ class AuthServiceTests {
     fun shouldFailLoginOnNonExistingUser(){
         every { authRepository.findByUsernameIgnoreCase(any()) } returns null
 
-       val exception = assertFailsWith<ApiException> {
+       val exception = assertThrows<ApiException> {
            authService.loginUser("u", "p")
        }
 
@@ -138,7 +138,7 @@ class AuthServiceTests {
         every { authRepository.findByUsernameIgnoreCase(any()) } returns UserEntity(username = "u", password = "")
         every { passwordService.checkPassword("p", any()) } returns false
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             authService.loginUser("u", "p")
         }
 

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/ChatFlushServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/ChatFlushServiceTests.kt
@@ -6,7 +6,7 @@ import com.blikeng.chatapp.services.ChatFlushService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 class ChatFlushServiceTests {
     // ==========================

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/NotificationServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/NotificationServiceTests.kt
@@ -1,16 +1,23 @@
 package com.blikeng.chatapp.serviceTests
 
 import com.blikeng.chatapp.dtos.invites.PendingInviteDTO
+import com.blikeng.chatapp.dtos.room.RoleAction
 import com.blikeng.chatapp.dtos.room.RoomAction
+import com.blikeng.chatapp.dtos.websocket.WsUserRoleChanged
 import com.blikeng.chatapp.entities.InviteType
 import com.blikeng.chatapp.events.InviteAcceptedEvent
 import com.blikeng.chatapp.events.InviteSentEvent
 import com.blikeng.chatapp.events.RoomDeletedEvent
+import com.blikeng.chatapp.events.UserBannedEvent
 import com.blikeng.chatapp.events.UserJoinedRoomEvent
 import com.blikeng.chatapp.events.UserRemovedEvent
+import com.blikeng.chatapp.events.UserRoleChangedEvent
 import com.blikeng.chatapp.messaging.redis.PresenceHandler
 import com.blikeng.chatapp.messaging.redis.PresenceKeys
+import com.blikeng.chatapp.security.UserRole
 import com.blikeng.chatapp.services.NotificationService
+import com.blikeng.chatapp.services.UserRevocationService
+import com.blikeng.chatapp.websocket.SessionRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -38,6 +45,8 @@ class NotificationServiceTests {
     @MockK lateinit var redisTemplate: RedisTemplate<String, String>
     @MockK lateinit var objectMapper: ObjectMapper
     @MockK lateinit var presenceHandler: PresenceHandler
+    @MockK lateinit var userRevocationService: UserRevocationService
+    @MockK lateinit var sessionRegistry: SessionRegistry
 
     @InjectMockKs lateinit var notificationService: NotificationService
 
@@ -168,5 +177,52 @@ class NotificationServiceTests {
         notificationService.onRoomDeleted(event)
 
         verify(exactly = 0) { redisTemplate.convertAndSend(any(), any<String>()) }
+    }
+
+    @Test
+    fun shouldSendBannedNotificationOnUserBanned() {
+        val targetId = UUID.randomUUID()
+        val event = UserBannedEvent(targetId, "Superuser", "spamming")
+
+        every { objectMapper.writeValueAsString(any()) } returns """{"type":"BANNED"}"""
+        every { redisTemplate.convertAndSend(any(), any<String>()) } returns 1L
+        every { userRevocationService.revokeBanned(targetId) } returns Unit
+        every { sessionRegistry.closeUserSessions(targetId) } returns Unit
+
+        notificationService.onUserBanned(event)
+
+        verify(exactly = 1) { redisTemplate.convertAndSend(PresenceKeys.userChannel(targetId), any<String>()) }
+    }
+
+    @Test
+    fun shouldSendUserRoleChangedNotification() {
+        val userId = UUID.randomUUID()
+        val event = UserRoleChangedEvent(
+            userId = userId,
+            byUsername = "admin",
+            newRole = UserRole.TRUSTED,
+            action = RoleAction.PROMOTE
+        )
+
+        every { objectMapper.writeValueAsString(any()) } returns """{"type":"USER_ROLE_CHANGED"}"""
+        every { redisTemplate.convertAndSend(any(), any<String>()) } returns 1L
+
+        notificationService.onUserRoleChanges(event)
+
+        verify(exactly = 1) {
+            objectMapper.writeValueAsString(match<WsUserRoleChanged> {
+                it.userId == userId &&
+                        it.byUsername == "admin" &&
+                        it.newRole == UserRole.TRUSTED &&
+                        it.action == RoleAction.PROMOTE
+            })
+        }
+
+        verify(exactly = 1) {
+            redisTemplate.convertAndSend(
+                PresenceKeys.userChannel(userId),
+                any<String>()
+            )
+        }
     }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/NotificationServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/NotificationServiceTests.kt
@@ -26,7 +26,10 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.data.redis.core.ListOperations
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
 import java.time.Instant
 import java.util.*
 
@@ -47,6 +50,9 @@ class NotificationServiceTests {
     @MockK lateinit var presenceHandler: PresenceHandler
     @MockK lateinit var userRevocationService: UserRevocationService
     @MockK lateinit var sessionRegistry: SessionRegistry
+    @MockK lateinit var rabbitTemplate: RabbitTemplate
+
+    @MockK lateinit var listOps: ListOperations<String, String>
 
     @InjectMockKs lateinit var notificationService: NotificationService
 
@@ -102,9 +108,7 @@ class NotificationServiceTests {
 
         notificationService.onInviteAccepted(event)
 
-        // INVITE_ACCEPTED + FRIEND_PRESENCE(toUserId) both go to fromUserId
         verify(exactly = 2) { redisTemplate.convertAndSend(PresenceKeys.userChannel(fromUserId), any<String>()) }
-        // FRIEND_PRESENCE(fromUserId) goes to toUserId
         verify(exactly = 1) { redisTemplate.convertAndSend(PresenceKeys.userChannel(toUserId), any<String>()) }
     }
 
@@ -117,6 +121,9 @@ class NotificationServiceTests {
         every { objectMapper.writeValueAsString(any()) } returns """{"type":"JOIN"}"""
         every { redisTemplate.convertAndSend(any(), any<String>()) } returns 1L
         every { presenceHandler.isUserOnline(userId) } returns true
+        every { redisTemplate.opsForList() } returns listOps
+        every { listOps.rightPush(any<String>(), any<String>()) } returns 1L
+        every { rabbitTemplate.convertAndSend(any<String>(), any<Any>()) } returns Unit
 
         notificationService.onUserJoinedRoom(event)
 

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/RoomBanServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/RoomBanServiceTests.kt
@@ -14,9 +14,9 @@ import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.*
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 
 @ExtendWith(MockKExtension::class)
 class RoomBanServiceTests {

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/UserRevocationServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/UserRevocationServiceTests.kt
@@ -66,4 +66,54 @@ class UserRevocationServiceTests {
 
         assertFalse(userRevocationService.isRevoked(userId))
     }
+
+    @Test
+    fun shouldBanUser() {
+        val userId = UUID.randomUUID()
+
+        every { redisTemplate.opsForValue() } returns valueOps
+        every { valueOps.set("banned_user:$userId", "1", Duration.ofHours(24)) } returns Unit
+
+        userRevocationService.revokeBanned(userId)
+
+        verify(exactly = 1) { valueOps.set("banned_user:$userId", "1", Duration.ofHours(24)) }
+    }
+
+    @Test
+    fun shouldReturnTrueWhenUserIsBanned() {
+        val userId = UUID.randomUUID()
+
+        every { redisTemplate.hasKey("banned_user:$userId") } returns true
+
+        assertTrue(userRevocationService.isBanned(userId))
+    }
+
+    @Test
+    fun shouldReturnFalseWhenUserIsNotInBannedList() {
+        val userId = UUID.randomUUID()
+
+        every { redisTemplate.hasKey("banned_user:$userId") } returns false
+
+        assertFalse(userRevocationService.isBanned(userId))
+    }
+
+    @Test
+    fun shouldReturnFalseWhenRedisReturnsNullForBannedUser() {
+        val userId = UUID.randomUUID()
+
+        every { redisTemplate.hasKey("banned_user:$userId") } returns null
+
+        assertFalse(userRevocationService.isBanned(userId))
+    }
+
+    @Test
+    fun shouldDeleteBannedUserKeyOnUnRevoke() {
+        val userId = UUID.randomUUID()
+
+        every { redisTemplate.delete("banned_user:$userId") } returns true
+
+        userRevocationService.unRevokeBanned(userId)
+
+        verify(exactly = 1) { redisTemplate.delete("banned_user:$userId") }
+    }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/UserRevocationServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/UserRevocationServiceTests.kt
@@ -12,8 +12,8 @@ import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ValueOperations
 import java.time.Duration
 import java.util.*
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 
 @ExtendWith(MockKExtension::class)
 class UserRevocationServiceTests {

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/UserServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/UserServiceTests.kt
@@ -464,7 +464,7 @@ class UserServiceTests {
 
         every { userRepository.findById(any()) } returns Optional.empty()
 
-        val exception = assertThrows<ApiException> { userService.getRole() }
+        val exception = assertThrows<ApiException> { userService.authenticate() }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/UserServiceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/UserServiceTests.kt
@@ -26,9 +26,9 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class UserServiceTests {
@@ -92,7 +92,7 @@ class UserServiceTests {
 
         every { userRepository.findById(any()) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.getSelf()
         }
 
@@ -107,7 +107,7 @@ class UserServiceTests {
 
         every { userRepository.findById(any()) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editProfile(ChangeUserDTO("","","",""))
         }
 
@@ -180,7 +180,7 @@ class UserServiceTests {
 
         every { userRepository.findById(userId) } returns Optional.of(UserEntity(id = userId, username = "username", password = ""))
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editProfile(ChangeUserDTO(bio = "a".repeat(501), email = "", fullName = "", avatarUrl = ""))
         }
 
@@ -196,7 +196,7 @@ class UserServiceTests {
 
         every { userRepository.findById(userId) } returns Optional.of(UserEntity(id = userId, username = "username", password = ""))
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editProfile(ChangeUserDTO(bio = "", email = "a".repeat(250) + "@b.com", fullName = "", avatarUrl = ""))
         }
 
@@ -212,7 +212,7 @@ class UserServiceTests {
 
         every { userRepository.findById(userId) } returns Optional.of(UserEntity(id = userId, username = "username", password = ""))
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editProfile(ChangeUserDTO(bio = "", email = "notanemail", fullName = "", avatarUrl = ""))
         }
 
@@ -242,7 +242,7 @@ class UserServiceTests {
 
         every { userRepository.findById(userId) } returns Optional.of(UserEntity(id = userId, username = "username", password = ""))
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editProfile(ChangeUserDTO(bio = "", email = "", fullName = "a".repeat(101), avatarUrl = ""))
         }
 
@@ -258,7 +258,7 @@ class UserServiceTests {
 
         every { userRepository.findById(userId) } returns Optional.of(UserEntity(id = userId, username = "username", password = ""))
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editProfile(ChangeUserDTO(bio = "", email = "", fullName = "", avatarUrl = "a".repeat(501)))
         }
 
@@ -299,7 +299,7 @@ class UserServiceTests {
 
         every { userRepository.findById(any()) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editPassword(
                 EditPasswordDTO(
                     oldPassword = "old password",
@@ -329,7 +329,7 @@ class UserServiceTests {
         every { userRepository.findById(userId) } returns Optional.of(user)
         every { passwordService.checkPassword(any(), any()) } returns false
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editPassword(
                 EditPasswordDTO(
                     oldPassword = "old passworded",
@@ -359,7 +359,7 @@ class UserServiceTests {
         every { userRepository.findById(userId) } returns Optional.of(user)
         every { passwordService.checkPassword(any(), any()) } returns true
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editPassword(
                 EditPasswordDTO(
                     oldPassword = "oldPassword",
@@ -376,7 +376,7 @@ class UserServiceTests {
 
     @Test
     fun shouldFailToGetUserWithoutAuthentication() {
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.getSelf()
         }
 
@@ -386,7 +386,7 @@ class UserServiceTests {
 
     @Test
     fun shouldFailToEditUserWithoutAuthentication() {
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editProfile(ChangeUserDTO("", "", "", ""))
         }
 
@@ -396,7 +396,7 @@ class UserServiceTests {
 
     @Test
     fun shouldFailToEditPasswordWithoutAuthentication() {
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.editPassword(EditPasswordDTO("oldPassword", "newPassword"))
         }
 
@@ -431,7 +431,7 @@ class UserServiceTests {
 
         every { userRepository.findById(any()) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             userService.deleteUser()
         }
 
@@ -464,7 +464,7 @@ class UserServiceTests {
 
         every { userRepository.findById(any()) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> { userService.getRole() }
+        val exception = assertThrows<ApiException> { userService.getRole() }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatBroadcastTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatBroadcastTests.kt
@@ -226,7 +226,7 @@ class ChatBroadcastTests {
         every { session.attributes } returns hashMapOf("userId" to userId)
 
         chatService.joinRoom(roomId, session)
-        chatService.rooms.remove(roomId)
+        chatService.sessionsInRooms.remove(roomId)
 
         clearMocks(session)
 

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatBroadcastTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatBroadcastTests.kt
@@ -35,7 +35,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.socket.WebSocketSession
 import java.util.*
 import java.util.Collections.emptyList
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class ChatBroadcastTests {
@@ -76,7 +76,7 @@ class ChatBroadcastTests {
     fun shouldFailToSendMessageIfNotAMember() {
         every { userRoomRepository.existsByIdUserIdAndIdRoomId(any(), any()) } returns false
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             chatService.broadcast(UUID.randomUUID(), ReceivedMessage(UUID.randomUUID(), UUID.randomUUID(), "hello", "MESSAGE"), "u")
         }
 
@@ -162,7 +162,7 @@ class ChatBroadcastTests {
 
         chatService.joinRoom(room.id, session)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             chatService.broadcast(room.id, ReceivedMessage(room.id, user.id, "         ", "MESSAGE"), "u")
         }
 
@@ -186,7 +186,7 @@ class ChatBroadcastTests {
 
         chatService.joinRoom(room.id, session)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             chatService.broadcast(room.id, ReceivedMessage(room.id, user.id, "a".repeat(10000), "MESSAGE"), "u")
         }
 
@@ -204,7 +204,7 @@ class ChatBroadcastTests {
         every { userRoomRepository.existsByIdUserIdAndIdRoomId(userId, roomId) } returns true
         every { roomRepository.findById(roomId) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             chatService.broadcast(roomId, ReceivedMessage(roomId, userId, "hello", "MESSAGE"), "u")
         }
 

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatBroadcastTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatBroadcastTests.kt
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.data.redis.core.ListOperations
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
 import org.springframework.http.HttpStatus
 import org.springframework.web.socket.WebSocketSession
 import java.util.*
@@ -56,6 +57,7 @@ class ChatBroadcastTests {
     @MockK lateinit var redisTemplate: RedisTemplate<String, String>
     @MockK lateinit var rabbitTemplate: RabbitTemplate
     @MockK lateinit var listOps: ListOperations<String, String>
+    @MockK lateinit var valueOps: ValueOperations<String, String>
     @MockK lateinit var presenceHandler: PresenceHandler
     @MockK lateinit var userService: UserService
     @MockK(relaxed = true) lateinit var meterRegistry: MeterRegistry
@@ -68,8 +70,12 @@ class ChatBroadcastTests {
         every { rabbitTemplate.convertAndSend(any<String>(), any<Any>()) } just Runs
         every { redisTemplate.convertAndSend(any<String>(), any<String>()) } returns 1L
         every { redisTemplate.opsForList() } returns listOps
+        every { redisTemplate.opsForValue() } returns valueOps
         every { listOps.rightPush(any<String>(), any<String>()) } returns 1L
         every { listOps.range(any<String>(), any<Long>(), any<Long>()) } returns emptyList()
+        every { valueOps.get(any<String>()) } returns null
+        every { valueOps.set(any<String>(), any<String>(), any<java.time.Duration>()) } just Runs
+        every { userRoomRepository.findAllIdUserIdsByIdRoomId(any()) } returns emptyList()
     }
 
     @Test
@@ -77,7 +83,7 @@ class ChatBroadcastTests {
         every { userRoomRepository.existsByIdUserIdAndIdRoomId(any(), any()) } returns false
 
         val ex = assertThrows<ApiException> {
-            chatService.broadcast(UUID.randomUUID(), ReceivedMessage(UUID.randomUUID(), UUID.randomUUID(), "hello", "MESSAGE"), "u")
+            chatService.broadcast(UUID.randomUUID(), UUID.randomUUID(), ReceivedMessage(UUID.randomUUID(), UUID.randomUUID(), "hello", "MESSAGE"), "u")
         }
 
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -101,7 +107,7 @@ class ChatBroadcastTests {
         chatService.joinRoom(roomId, session1)
         chatService.joinRoom(roomId, session2)
 
-        chatService.broadcast(roomId, ReceivedMessage(roomId, userId, "hello", "MESSAGE"), "u")
+        chatService.broadcast(roomId, userId, ReceivedMessage(roomId, userId, "hello", "MESSAGE"), "u")
 
         verify(exactly = 1) { rabbitTemplate.convertAndSend("chat.buffer", any<Any>()) }
         verify(exactly = 1) { listOps.rightPush("chat.peek.${roomId}", any<String>()) }
@@ -115,11 +121,12 @@ class ChatBroadcastTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(any(), any()) } returns UserRoomEntity(UserRoomId(UUID.randomUUID(), UUID.randomUUID()), RoomRole.MEMBER, RoomType.GROUP)
 
         val roomId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
         val session = mockk<WebSocketSession>(relaxed = true)
-        every { session.attributes } returns hashMapOf("userId" to UUID.randomUUID())
+        every { session.attributes } returns hashMapOf("userId" to userId)
 
         chatService.joinRoom(roomId, session)
-        chatService.broadcast(roomId, ReceivedMessage(roomId, UUID.randomUUID(), "join", "JOIN"), "u")
+        chatService.broadcast(roomId, userId, ReceivedMessage(roomId, UUID.randomUUID(), "join", "JOIN"), "u")
 
         verify(exactly = 0) { session.sendMessage(any()) }
     }
@@ -140,7 +147,7 @@ class ChatBroadcastTests {
         every { session.attributes } returns hashMapOf("userId" to user.id)
 
         chatService.joinRoom(room.id, session)
-        chatService.broadcast(room.id, ReceivedMessage(room.id, user.id, "secret", "MESSAGE"), "u")
+        chatService.broadcast(room.id, user.id, ReceivedMessage(room.id, user.id, "secret", "MESSAGE"), "u")
 
         verify(exactly = 1) { rabbitTemplate.convertAndSend("chat.buffer", any<Any>()) }
         verify(exactly = 1) { listOps.rightPush("chat.peek.${room.id}", any<String>()) }
@@ -163,7 +170,7 @@ class ChatBroadcastTests {
         chatService.joinRoom(room.id, session)
 
         val exception = assertThrows<ApiException> {
-            chatService.broadcast(room.id, ReceivedMessage(room.id, user.id, "         ", "MESSAGE"), "u")
+            chatService.broadcast(room.id, user.id, ReceivedMessage(room.id, user.id, "         ", "MESSAGE"), "u")
         }
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -187,7 +194,7 @@ class ChatBroadcastTests {
         chatService.joinRoom(room.id, session)
 
         val exception = assertThrows<ApiException> {
-            chatService.broadcast(room.id, ReceivedMessage(room.id, user.id, "a".repeat(10000), "MESSAGE"), "u")
+            chatService.broadcast(room.id, user.id, ReceivedMessage(room.id, user.id, "a".repeat(10000), "MESSAGE"), "u")
         }
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -205,12 +212,79 @@ class ChatBroadcastTests {
         every { roomRepository.findById(roomId) } returns Optional.empty()
 
         val exception = assertThrows<ApiException> {
-            chatService.broadcast(roomId, ReceivedMessage(roomId, userId, "hello", "MESSAGE"), "u")
+            chatService.broadcast(roomId, userId, ReceivedMessage(roomId, userId, "hello", "MESSAGE"), "u")
         }
 
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
         assertEquals(ErrorMessages.ROOM_NOT_FOUND, exception.message)
         verify(exactly = 0) { rabbitTemplate.convertAndSend("chat.buffer", any<Any>()) }
+    }
+
+    @Test
+    fun shouldDefaultRoomNameWhenNotCached() {
+        val roomId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        val memberId = UUID.randomUUID()
+
+        every { userRoomRepository.existsByIdUserIdAndIdRoomId(any(), any()) } returns true
+        every { userRoomRepository.findAllIdUserIdsByIdRoomId(roomId) } returns listOf(memberId)
+        every { presenceHandler.isUserOnline(memberId) } returns true
+
+        val channels = mutableListOf<String>()
+        val payloads = mutableListOf<String>()
+        every { redisTemplate.convertAndSend(capture(channels), capture(payloads)) } returns 1L
+
+        chatService.broadcast(roomId, userId, ReceivedMessage(roomId, userId, "u joined", "JOIN"), "u")
+
+        val idx = channels.indexOfFirst { it == "user:$memberId" }
+        val json = objectMapper.readTree(payloads[idx])
+        assertEquals("MESSAGE_NOTIFICATION", json["type"].asText())
+        assertEquals("Unknown room", json["roomName"].asText())
+    }
+
+    @Test
+    fun shouldPublishTypingToRoomChannel() {
+        val roomId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+
+        val payloadSlot = slot<String>()
+        every { redisTemplate.convertAndSend(eq("room:$roomId"), capture(payloadSlot)) } returns 1L
+
+        chatService.notifyTyping(roomId, userId, "alice")
+
+        val json = objectMapper.readTree(payloadSlot.captured)
+        assertEquals("TYPING", json["type"].asText())
+        assertEquals(userId.toString(), json["userId"].asText())
+        assertEquals(roomId.toString(), json["roomId"].asText())
+        assertEquals("alice", json["username"].asText())
+    }
+
+    @Test
+    fun shouldReturnCachedRoomMemberIds() {
+        val roomId = UUID.randomUUID()
+        val memberId = UUID.randomUUID()
+
+        every { valueOps.get("room:$roomId:members") } returns objectMapper.writeValueAsString(listOf(memberId))
+
+        val result = chatService.getRoomMemberIds(roomId)
+
+        assertEquals(listOf(memberId), result)
+        verify(exactly = 0) { userRoomRepository.findAllIdUserIdsByIdRoomId(any()) }
+    }
+
+    @Test
+    fun shouldNotSendNotificationToOfflineMember() {
+        val roomId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        val memberId = UUID.randomUUID()
+
+        every { userRoomRepository.existsByIdUserIdAndIdRoomId(any(), any()) } returns true
+        every { userRoomRepository.findAllIdUserIdsByIdRoomId(roomId) } returns listOf(memberId)
+        every { presenceHandler.isUserOnline(memberId) } returns false
+
+        chatService.broadcast(roomId, userId, ReceivedMessage(roomId, userId, "hi", "JOIN"), "u")
+
+        verify(exactly = 0) { redisTemplate.convertAndSend(eq("user:$memberId"), any<String>()) }
     }
 
     @Test
@@ -230,7 +304,7 @@ class ChatBroadcastTests {
 
         clearMocks(session)
 
-        chatService.broadcast(roomId, ReceivedMessage(roomId, userId, "hello", "MESSAGE"), "u")
+        chatService.broadcast(roomId, userId, ReceivedMessage(roomId, userId, "hello", "MESSAGE"), "u")
 
         verify(exactly = 0) { session.sendMessage(any()) }
     }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatMessageHistoryTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatMessageHistoryTests.kt
@@ -294,8 +294,8 @@ class ChatMessageHistoryTests {
         val roomsGauge = meterRegistry.get("chat.rooms").gauge()
         assertEquals(0.0, roomsGauge.value())
 
-        chatService.rooms[UUID.randomUUID()] = CopyOnWriteArraySet(mutableSetOf(mockk()))
-        chatService.rooms[UUID.randomUUID()] = CopyOnWriteArraySet(mutableSetOf(mockk()))
+        chatService.sessionsInRooms[UUID.randomUUID()] = CopyOnWriteArraySet(mutableSetOf(mockk()))
+        chatService.sessionsInRooms[UUID.randomUUID()] = CopyOnWriteArraySet(mutableSetOf(mockk()))
 
         assertEquals(2.0, roomsGauge.value())
     }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatMessageHistoryTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatMessageHistoryTests.kt
@@ -36,7 +36,7 @@ import java.time.Instant
 import java.util.*
 import java.util.Collections.emptyList
 import java.util.concurrent.CopyOnWriteArraySet
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class ChatMessageHistoryTests {
@@ -159,13 +159,13 @@ class ChatMessageHistoryTests {
 
     @Test
     fun shouldFailToGetMessagesWhenUsingInvalidParameters() {
-        val pageNumberException = assertFailsWith<ApiException> {
+        val pageNumberException = assertThrows<ApiException> {
             chatService.getRoomMessages(UUID.randomUUID(), -1, 25)
         }
         assertEquals(HttpStatus.BAD_REQUEST, pageNumberException.status)
         assertEquals(ErrorMessages.INVALID_PARAMETERS, pageNumberException.message)
 
-        val pageSizeException = assertFailsWith<ApiException> {
+        val pageSizeException = assertThrows<ApiException> {
             chatService.getRoomMessages(UUID.randomUUID(), 0, 250)
         }
         assertEquals(HttpStatus.BAD_REQUEST, pageSizeException.status)
@@ -177,7 +177,7 @@ class ChatMessageHistoryTests {
         val roomId = UUID.randomUUID()
         every { roomRepository.findById(roomId) } returns Optional.empty()
 
-        val ex = assertFailsWith<ApiException> { chatService.getRoomMessages(roomId, 0, 25) }
+        val ex = assertThrows<ApiException> { chatService.getRoomMessages(roomId, 0, 25) }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
     }
 
@@ -224,7 +224,7 @@ class ChatMessageHistoryTests {
         val pending = RabbitMessageDTO(roomId = room.id, userId = user.id, username = user.username)
         every { listOps.range("chat.peek.${room.id}", 0L, -1L) } returns listOf(objectMapper.writeValueAsString(pending))
 
-        val ex = assertFailsWith<ApiException> { chatService.getRoomMessages(room.id, 0, 25) }
+        val ex = assertThrows<ApiException> { chatService.getRoomMessages(room.id, 0, 25) }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 
@@ -239,7 +239,7 @@ class ChatMessageHistoryTests {
         val pending = RabbitMessageDTO(roomId = room.id, userId = user.id, username = user.username, ciphertext = "cipher".toByteArray(), nonce = null)
         every { listOps.range("chat.peek.${room.id}", 0L, -1L) } returns listOf(objectMapper.writeValueAsString(pending))
 
-        val ex = assertFailsWith<ApiException> { chatService.getRoomMessages(room.id, 0, 25) }
+        val ex = assertThrows<ApiException> { chatService.getRoomMessages(room.id, 0, 25) }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 
@@ -253,7 +253,7 @@ class ChatMessageHistoryTests {
         every { roomRepository.findById(room.id) } returns Optional.of(room)
         every { chatRepository.findByRoomIdOrderByTimestampDesc(eq(room.id), any()) } returns PageImpl(listOf(chat))
 
-        val ex = assertFailsWith<ApiException> { chatService.getRoomMessages(room.id, 0, 25) }
+        val ex = assertThrows<ApiException> { chatService.getRoomMessages(room.id, 0, 25) }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 
@@ -267,7 +267,7 @@ class ChatMessageHistoryTests {
         every { roomRepository.findById(room.id) } returns Optional.of(room)
         every { chatRepository.findByRoomIdOrderByTimestampDesc(eq(room.id), any()) } returns PageImpl(listOf(chat))
 
-        val ex = assertFailsWith<ApiException> { chatService.getRoomMessages(room.id, 0, 25) }
+        val ex = assertThrows<ApiException> { chatService.getRoomMessages(room.id, 0, 25) }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatRoomSessionTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatRoomSessionTests.kt
@@ -37,7 +37,7 @@ import org.springframework.web.socket.WebSocketSession
 import java.util.*
 import java.util.Collections.emptyList
 import java.util.concurrent.CopyOnWriteArraySet
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class ChatRoomSessionTests {
@@ -233,7 +233,7 @@ class ChatRoomSessionTests {
         val session = mockk<WebSocketSession>()
         every { session.attributes } returns emptyMap()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             chatService.joinRoom(UUID.randomUUID(), session)
         }
 
@@ -247,7 +247,7 @@ class ChatRoomSessionTests {
         every { session.attributes } returns hashMapOf("userId" to UUID.randomUUID())
         every { userRoomRepository.findByIdUserIdAndIdRoomId(any(), any()) } answers { null }
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             chatService.joinRoom(UUID.randomUUID(), session)
         }
 
@@ -262,7 +262,7 @@ class ChatRoomSessionTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(any(), any()) } returns UserRoomEntity(UserRoomId(UUID.randomUUID(), UUID.randomUUID()), RoomRole.MEMBER, RoomType.GROUP)
         every { roomRepository.findById(any()) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             chatService.joinRoom(UUID.randomUUID(), session)
         }
 

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatRoomSessionTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/chatServiceTests/ChatRoomSessionTests.kt
@@ -32,7 +32,6 @@ import org.springframework.data.redis.core.ListOperations
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ValueOperations
 import org.springframework.http.HttpStatus
-import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import java.util.*
 import java.util.Collections.emptyList
@@ -98,13 +97,13 @@ class ChatRoomSessionTests {
         chatService.joinRoom(roomId, session)
         chatService.joinRoom(roomId2, session)
 
-        assertEquals(chatService.rooms[roomId]?.first(), session)
-        assertEquals(chatService.rooms[roomId2]?.first(), session)
+        assertEquals(chatService.sessionsInRooms[roomId]?.first(), session)
+        assertEquals(chatService.sessionsInRooms[roomId2]?.first(), session)
 
         chatService.removeSessionFromRooms(session)
 
-        assertNull(chatService.rooms[roomId])
-        assertNull(chatService.rooms[roomId2])
+        assertNull(chatService.sessionsInRooms[roomId])
+        assertNull(chatService.sessionsInRooms[roomId2])
     }
 
     @Test
@@ -135,7 +134,7 @@ class ChatRoomSessionTests {
 
         chatService.removeSessionFromRooms(session)
 
-        assertNotNull(chatService.rooms[roomId])
+        assertNotNull(chatService.sessionsInRooms[roomId])
     }
 
     @Test
@@ -149,12 +148,12 @@ class ChatRoomSessionTests {
         every { session1.attributes } returns hashMapOf("userId" to userId)
         every { session2.attributes } returns hashMapOf("userId" to userId)
 
-        chatService.rooms[roomId] = mutableSetOf(session1, session2)
+        chatService.sessionsInRooms[roomId] = mutableSetOf(session1, session2)
 
         chatService.removeSessionFromRooms(session1)
 
-        assertNotNull(chatService.rooms[roomId])
-        assertTrue(chatService.rooms[roomId]?.contains(session2) == true)
+        assertNotNull(chatService.sessionsInRooms[roomId])
+        assertTrue(chatService.sessionsInRooms[roomId]?.contains(session2) == true)
     }
 
     // ==========================
@@ -177,7 +176,7 @@ class ChatRoomSessionTests {
 
         chatService.joinRoom(roomId, session)
 
-        assertEquals(session, chatService.rooms[roomId]?.first())
+        assertEquals(session, chatService.sessionsInRooms[roomId]?.first())
     }
 
     @Test
@@ -195,7 +194,7 @@ class ChatRoomSessionTests {
 
         chatService.joinRoom(roomId, session)
 
-        assertTrue(chatService.rooms[roomId]?.contains(session) == true)
+        assertTrue(chatService.sessionsInRooms[roomId]?.contains(session) == true)
         verify(exactly = 0) { session.sendMessage(any()) }
     }
 
@@ -291,10 +290,10 @@ class ChatRoomSessionTests {
         every { userService.getAllById(any()) } returns emptyList()
 
         chatService.joinRoom(roomId, session)
-        assertEquals(session, chatService.rooms[roomId]?.first())
+        assertEquals(session, chatService.sessionsInRooms[roomId]?.first())
 
         chatService.leaveRoom(roomId, session)
-        assertNull(chatService.rooms[roomId])
+        assertNull(chatService.sessionsInRooms[roomId])
     }
 
     @Test
@@ -309,7 +308,7 @@ class ChatRoomSessionTests {
         every { remainingSession.isOpen } returns false
         every { presenceHandler.isUserOnline(any()) } returns false
 
-        chatService.rooms[roomId] = CopyOnWriteArraySet(mutableSetOf(leavingSession, remainingSession))
+        chatService.sessionsInRooms[roomId] = CopyOnWriteArraySet(mutableSetOf(leavingSession, remainingSession))
 
         chatService.leaveRoom(roomId, leavingSession)
 
@@ -323,7 +322,7 @@ class ChatRoomSessionTests {
         val session = mockk<WebSocketSession>()
         every { session.attributes } returns hashMapOf("userId" to UUID.randomUUID())
 
-        assertNull(chatService.rooms[UUID.randomUUID()])
+        assertNull(chatService.sessionsInRooms[UUID.randomUUID()])
         chatService.leaveRoom(UUID.randomUUID(), session)
     }
 
@@ -333,7 +332,7 @@ class ChatRoomSessionTests {
         every { session.attributes } returns hashMapOf("userId" to "")
 
         chatService.leaveRoom(UUID.randomUUID(), session)
-        assertNull(chatService.rooms[UUID.randomUUID()])
+        assertNull(chatService.sessionsInRooms[UUID.randomUUID()])
     }
 
     @Test
@@ -361,13 +360,13 @@ class ChatRoomSessionTests {
         chatService.joinRoom(roomId, session1)
         chatService.joinRoom(roomId, session2)
 
-        assertEquals(2, chatService.rooms[roomId]?.size)
+        assertEquals(2, chatService.sessionsInRooms[roomId]?.size)
 
         chatService.leaveRoom(roomId, session1)
 
-        assertEquals(1, chatService.rooms[roomId]?.size)
-        assertFalse(chatService.rooms[roomId]?.contains(session1) == true)
-        assertTrue(chatService.rooms[roomId]?.contains(session2) == true)
+        assertEquals(1, chatService.sessionsInRooms[roomId]?.size)
+        assertFalse(chatService.sessionsInRooms[roomId]?.contains(session1) == true)
+        assertTrue(chatService.sessionsInRooms[roomId]?.contains(session2) == true)
     }
 
     @Test
@@ -384,13 +383,13 @@ class ChatRoomSessionTests {
         every { invalidSession.isOpen } returns true
         every { invalidSession.sendMessage(any()) } just Runs
 
-        chatService.rooms[roomId] = CopyOnWriteArraySet(mutableSetOf(leavingSession, invalidSession))
+        chatService.sessionsInRooms[roomId] = CopyOnWriteArraySet(mutableSetOf(leavingSession, invalidSession))
 
         chatService.leaveRoom(roomId, leavingSession)
 
-        assertNotNull(chatService.rooms[roomId])
-        assertEquals(1, chatService.rooms[roomId]?.size)
-        assertTrue(chatService.rooms[roomId]?.contains(invalidSession) == true)
+        assertNotNull(chatService.sessionsInRooms[roomId])
+        assertEquals(1, chatService.sessionsInRooms[roomId]?.size)
+        assertTrue(chatService.sessionsInRooms[roomId]?.contains(invalidSession) == true)
     }
 
     // ==========================

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/friendServiceTests/FriendMutationTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/friendServiceTests/FriendMutationTests.kt
@@ -31,7 +31,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import com.blikeng.chatapp.dtos.UserIdDTO
 import java.util.*
 import java.util.Optional
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class FriendMutationTests {
@@ -131,7 +131,7 @@ class FriendMutationTests {
     fun shouldFailToAddFriendsWithInvalidUser() {
         every { userService.getUserById(user1.id) } returns null
 
-        val exception = assertFailsWith<ApiException> { friendService.addFriend(user1.id, user2.id) }
+        val exception = assertThrows<ApiException> { friendService.addFriend(user1.id, user2.id) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -140,13 +140,13 @@ class FriendMutationTests {
         every { userService.getUserById(user1.id) } returns user1
         every { userService.getUserById(user2.id) } returns null
 
-        val exception = assertFailsWith<ApiException> { friendService.addFriend(user1.id, user2.id) }
+        val exception = assertThrows<ApiException> { friendService.addFriend(user1.id, user2.id) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
     @Test
     fun shouldFailToAddYourselfAsFriend() {
-        val exception = assertFailsWith<ApiException> { friendService.addFriend(user1.id, user1.id) }
+        val exception = assertThrows<ApiException> { friendService.addFriend(user1.id, user1.id) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -202,7 +202,7 @@ class FriendMutationTests {
         every { userService.getUserById(user1.id) } returns user1
         every { userRepository.findById(user2.id) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> { friendService.removeFriend(UserIdDTO(user2.id.toString())) }
+        val exception = assertThrows<ApiException> { friendService.removeFriend(UserIdDTO(user2.id.toString())) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -215,7 +215,7 @@ class FriendMutationTests {
         every { userRepository.findById(user2.id) } returns Optional.of(user2)
         every { friendsRepository.existsById(any()) } returns false
 
-        val exception = assertFailsWith<ApiException> { friendService.removeFriend(UserIdDTO(user2.id.toString())) }
+        val exception = assertThrows<ApiException> { friendService.removeFriend(UserIdDTO(user2.id.toString())) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -226,7 +226,7 @@ class FriendMutationTests {
 
         every { userService.getUserById(user1.id) } returns user1
 
-        val exception = assertFailsWith<ApiException> { friendService.removeFriend(UserIdDTO("not-a-uuid")) }
+        val exception = assertThrows<ApiException> { friendService.removeFriend(UserIdDTO("not-a-uuid")) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/friendServiceTests/FriendPresenceTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/friendServiceTests/FriendPresenceTests.kt
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ValueOperations
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @ExtendWith(MockKExtension::class)
 class FriendPresenceTests {

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/friendServiceTests/FriendQueryTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/friendServiceTests/FriendQueryTests.kt
@@ -28,7 +28,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
 import java.util.Optional
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class FriendQueryTests {
@@ -116,7 +116,7 @@ class FriendQueryTests {
         every { userService.getUserById(user1.id) } returns user1
         every { userRepository.findById(user2.id) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> { friendService.getFriendInfo(user2.id.toString()) }
+        val exception = assertThrows<ApiException> { friendService.getFriendInfo(user2.id.toString()) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -129,7 +129,7 @@ class FriendQueryTests {
         every { userRepository.findById(user2.id) } returns Optional.of(user2)
         every { friendsRepository.findById(any()) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> { friendService.getFriendInfo(user2.id.toString()) }
+        val exception = assertThrows<ApiException> { friendService.getFriendInfo(user2.id.toString()) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -140,7 +140,7 @@ class FriendQueryTests {
 
         every { userService.getUserById(user1.id) } returns user1
 
-        val exception = assertFailsWith<ApiException> { friendService.getFriendInfo("not-a-uuid") }
+        val exception = assertThrows<ApiException> { friendService.getFriendInfo("not-a-uuid") }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -162,7 +162,7 @@ class FriendQueryTests {
     fun shouldFailToGetFriendEntityWhenUserDoesNotExist() {
         every { userRepository.findById(user2.id) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> { friendService.getFriendEntityById(user2.id, user1.id) }
+        val exception = assertThrows<ApiException> { friendService.getFriendEntityById(user2.id, user1.id) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -171,7 +171,7 @@ class FriendQueryTests {
         every { userRepository.findById(user2.id) } returns Optional.of(user2)
         every { friendsRepository.existsById(any()) } returns false
 
-        val exception = assertFailsWith<ApiException> { friendService.getFriendEntityById(user2.id, user1.id) }
+        val exception = assertThrows<ApiException> { friendService.getFriendEntityById(user2.id, user1.id) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/inviteServiceTests/InviteOutgoingTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/inviteServiceTests/InviteOutgoingTests.kt
@@ -34,9 +34,9 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import java.time.Instant
 import java.util.*
-import kotlin.test.assertFailsWith
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 
 @ExtendWith(MockKExtension::class)
 class InviteOutgoingTests {
@@ -96,7 +96,7 @@ class InviteOutgoingTests {
         val result = inviteService.getOutgoingInvites()
 
         assertEquals(1, result.size)
-        assertIs<OutgoingFriendRequestDTO>(result[0])
+        assertInstanceOf(OutgoingFriendRequestDTO::class.java, result[0])
         assertEquals(user2.id, (result[0] as OutgoingFriendRequestDTO).toUserId)
         assertEquals(user2.username, (result[0] as OutgoingFriendRequestDTO).toUsername)
     }
@@ -119,7 +119,7 @@ class InviteOutgoingTests {
         val result = inviteService.getOutgoingInvites()
 
         assertEquals(1, result.size)
-        assertIs<OutgoingRoomInviteDTO>(result[0])
+        assertInstanceOf(OutgoingRoomInviteDTO::class.java, result[0])
         assertEquals(roomId, (result[0] as OutgoingRoomInviteDTO).roomId)
         assertEquals(user2.username, (result[0] as OutgoingRoomInviteDTO).toUsername)
     }
@@ -142,7 +142,7 @@ class InviteOutgoingTests {
         val result = inviteService.getOutgoingInvites()
 
         assertEquals(1, result.size)
-        assertIs<OutgoingOpenRoomInviteDTO>(result[0])
+        assertInstanceOf(OutgoingOpenRoomInviteDTO::class.java, result[0])
         assertEquals(roomId, (result[0] as OutgoingOpenRoomInviteDTO).roomId)
         assertEquals(3, (result[0] as OutgoingOpenRoomInviteDTO).usages)
         assertEquals(10, (result[0] as OutgoingOpenRoomInviteDTO).maxUsages)
@@ -172,7 +172,7 @@ class InviteOutgoingTests {
         every { userService.getUserById(user1.id) } returns user1
         every { inviteRepository.findByFromUserIdAndStatus(user1.id, InviteStatus.PENDING) } returns listOf(invite)
 
-        val ex = assertFailsWith<ApiException> { inviteService.getOutgoingInvites() }
+        val ex = assertThrows<ApiException> { inviteService.getOutgoingInvites() }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 
@@ -190,7 +190,7 @@ class InviteOutgoingTests {
         every { userService.getUserById(user1.id) } returns user1
         every { inviteRepository.findByFromUserIdAndStatus(user1.id, InviteStatus.PENDING) } returns listOf(invite)
 
-        val ex = assertFailsWith<ApiException> { inviteService.getOutgoingInvites() }
+        val ex = assertThrows<ApiException> { inviteService.getOutgoingInvites() }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 
@@ -209,7 +209,7 @@ class InviteOutgoingTests {
         every { inviteRepository.findByFromUserIdAndStatus(user1.id, InviteStatus.PENDING) } returns listOf(invite)
         every { userRepository.findById(user2.id) } returns Optional.of(user2)
 
-        val ex = assertFailsWith<ApiException> { inviteService.getOutgoingInvites() }
+        val ex = assertThrows<ApiException> { inviteService.getOutgoingInvites() }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 
@@ -228,7 +228,7 @@ class InviteOutgoingTests {
         every { userService.getUserById(user1.id) } returns user1
         every { inviteRepository.findByFromUserIdAndStatus(user1.id, InviteStatus.PENDING) } returns listOf(invite)
 
-        val ex = assertFailsWith<ApiException> { inviteService.getOutgoingInvites() }
+        val ex = assertThrows<ApiException> { inviteService.getOutgoingInvites() }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 
@@ -246,7 +246,7 @@ class InviteOutgoingTests {
         every { inviteRepository.findByFromUserIdAndStatus(user1.id, InviteStatus.PENDING) } returns listOf(invite)
         every { userRepository.findById(user2.id) } returns Optional.empty()
 
-        val ex = assertFailsWith<ApiException> { inviteService.getOutgoingInvites() }
+        val ex = assertThrows<ApiException> { inviteService.getOutgoingInvites() }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
     }
 
@@ -265,7 +265,7 @@ class InviteOutgoingTests {
         every { inviteRepository.findByFromUserIdAndStatus(user1.id, InviteStatus.PENDING) } returns listOf(invite)
         every { userRepository.findById(user2.id) } returns Optional.empty()
 
-        val ex = assertFailsWith<ApiException> { inviteService.getOutgoingInvites() }
+        val ex = assertThrows<ApiException> { inviteService.getOutgoingInvites() }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
     }
 
@@ -284,7 +284,7 @@ class InviteOutgoingTests {
         every { userService.getUserById(user1.id) } returns user1
         every { inviteRepository.findByFromUserIdAndStatus(user1.id, InviteStatus.PENDING) } returns listOf(invite)
 
-        val ex = assertFailsWith<ApiException> { inviteService.getOutgoingInvites() }
+        val ex = assertThrows<ApiException> { inviteService.getOutgoingInvites() }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 
@@ -303,7 +303,7 @@ class InviteOutgoingTests {
         every { userService.getUserById(user1.id) } returns user1
         every { inviteRepository.findByFromUserIdAndStatus(user1.id, InviteStatus.PENDING) } returns listOf(invite)
 
-        val ex = assertFailsWith<ApiException> { inviteService.getOutgoingInvites() }
+        val ex = assertThrows<ApiException> { inviteService.getOutgoingInvites() }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
     }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/inviteServiceTests/InviteResponseTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/inviteServiceTests/InviteResponseTests.kt
@@ -36,8 +36,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import java.time.Instant
 import java.util.*
-import kotlin.test.assertFailsWith
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @ExtendWith(MockKExtension::class)
 class InviteResponseTests {
@@ -121,7 +121,7 @@ class InviteResponseTests {
         every { userService.getUserById(user2.id) } returns null
         every { inviteRepository.findById(invite.id) } returns Optional.of(invite)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -148,7 +148,7 @@ class InviteResponseTests {
         every { userService.getUserById(user2.id) } returns user2
         every { inviteRepository.findById(wrongInvite.id) } returns Optional.of(wrongInvite)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = wrongInvite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -181,7 +181,7 @@ class InviteResponseTests {
         every { userService.getUserById(user2.id) } returns null
         every { inviteRepository.findById(invite.id) } returns Optional.of(invite)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -239,7 +239,7 @@ class InviteResponseTests {
         every { userService.getUserById(user2.id) } returns user2
         every { inviteRepository.findById(wrongInvite.id) } returns Optional.of(wrongInvite)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = wrongInvite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -264,7 +264,7 @@ class InviteResponseTests {
         every { inviteRepository.findById(invite.id) } returns Optional.of(invite)
         every { userRoomRepository.existsByIdUserIdAndIdRoomId(user1.id, roomId) } returns true
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.CONFLICT, ex.status)
@@ -287,7 +287,7 @@ class InviteResponseTests {
         every { userRoomRepository.existsByIdUserIdAndIdRoomId(user1.id, roomId) } returns false
         every { bannedUserService.isUserBanned(user1.id, roomId) } returns true
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.FORBIDDEN, ex.status)
@@ -311,7 +311,7 @@ class InviteResponseTests {
         every { bannedUserService.isUserBanned(user1.id, roomId) } returns false
         every { inviteRepository.incrementUsagesIfAvailable(invite.id) } returns 0
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -332,7 +332,7 @@ class InviteResponseTests {
         every { inviteRepository.findById(invite.id) } returns Optional.of(invite)
         every { userService.getUserById(user2.id) } returns user2
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -353,7 +353,7 @@ class InviteResponseTests {
         every { userService.getUserById(user1.id) } returns user1
         every { inviteRepository.findById(invite.id) } returns Optional.of(invite)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -379,7 +379,7 @@ class InviteResponseTests {
         every { inviteRepository.deleteByToUserIdAndRoomId(user1.id, roomId) } just Runs
         every { roomService.joinRoom(user1.id, roomId) } just Runs
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -484,7 +484,7 @@ class InviteResponseTests {
         every { userService.getUserById(user1.id) } returns user1
         every { inviteRepository.findById(invite.id) } returns Optional.of(invite)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -495,7 +495,7 @@ class InviteResponseTests {
         setAuth(user1.id)
         every { userService.getUserById(user1.id) } returns null
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = UUID.randomUUID().toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -508,7 +508,7 @@ class InviteResponseTests {
         every { userService.getUserById(user1.id) } returns user1
         every { inviteRepository.findById(id) } returns Optional.empty()
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -528,7 +528,7 @@ class InviteResponseTests {
         every { inviteRepository.findById(invite.id) } returns Optional.of(invite)
         every { inviteRepository.save(any()) } answers { firstArg() }
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = invite.id.toString(), response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -540,7 +540,7 @@ class InviteResponseTests {
         setAuth(user1.id)
         every { userService.getUserById(user1.id) } returns user1
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.respondToRequest(InviteResponseDTO(inviteId = "not-a-uuid", response = InviteResponse.ACCEPTED))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/inviteServiceTests/InviteSendTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/inviteServiceTests/InviteSendTests.kt
@@ -43,8 +43,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import java.time.Instant
 import java.util.*
-import kotlin.test.assertFailsWith
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @ExtendWith(MockKExtension::class)
 class InviteSendTests {
@@ -164,7 +164,7 @@ class InviteSendTests {
     fun shouldFailToSendFriendRequestWithEmptyUsername() {
         setAuth(user1.id)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendFriendRequest(FriendRequestDTO(username = "  "))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -175,7 +175,7 @@ class InviteSendTests {
         setAuth(user1.id)
         every { userService.getUserById(user1.id) } returns null
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendFriendRequest(FriendRequestDTO(username = "user2"))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -187,7 +187,7 @@ class InviteSendTests {
         every { userService.getUserById(user1.id) } returns user1
         every { userRepository.getUserByUsernameIgnoreCase("ghost") } returns null
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendFriendRequest(FriendRequestDTO(username = "ghost"))
         }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -199,7 +199,7 @@ class InviteSendTests {
         every { userService.getUserById(user1.id) } returns user1
         every { userRepository.getUserByUsernameIgnoreCase("user1") } returns user1
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendFriendRequest(FriendRequestDTO(username = "user1"))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -212,7 +212,7 @@ class InviteSendTests {
         every { userRepository.getUserByUsernameIgnoreCase("user2") } returns user2
         every { inviteRepository.existsPendingFriendRequest(user1.id, user2.id) } returns true
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendFriendRequest(FriendRequestDTO(username = "user2"))
         }
         assertEquals(HttpStatus.CONFLICT, ex.status)
@@ -226,7 +226,7 @@ class InviteSendTests {
         every { inviteRepository.existsPendingFriendRequest(user1.id, user2.id) } returns false
         every { friendService.areFriends(user1.id, user2.id) } returns true
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendFriendRequest(FriendRequestDTO(username = "user2"))
         }
         assertEquals(HttpStatus.CONFLICT, ex.status)
@@ -315,7 +315,7 @@ class InviteSendTests {
         setAuth(user1.id)
         every { userService.getUserById(user1.id) } returns null
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user2.username, roomId = roomId.toString()))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -331,7 +331,7 @@ class InviteSendTests {
         every { roomService.getRoom(roomId) } returns Optional.of(mockk<RoomEntity>())
         every { userRepository.getUserByUsernameIgnoreCase(user1.username) } returns user1
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user1.username, roomId = roomId.toString()))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -341,7 +341,7 @@ class InviteSendTests {
     fun shouldFailToSendRoomInviteWithInvalidRoomId() {
         setAuth(user1.id)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user2.username, roomId = "not-a-uuid"))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -353,7 +353,7 @@ class InviteSendTests {
         every { userService.getUserById(user1.id) } returns user1
         every { userRoomRepository.findByIdUserIdAndIdRoomId(user1.id, roomId) } returns null
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user2.username, roomId = roomId.toString()))
         }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -368,7 +368,7 @@ class InviteSendTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(user1.id, roomId) } returns userRoom
         every { roomService.getRoom(roomId) } returns Optional.of(mockk<RoomEntity>())
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user2.username, roomId = roomId.toString()))
         }
         assertEquals(HttpStatus.FORBIDDEN, ex.status)
@@ -386,7 +386,7 @@ class InviteSendTests {
         every { userRoomRepository.existsByIdUserIdAndIdRoomId(user2.id, roomId) } returns false
         every { bannedUserService.isUserBanned(user2.id, roomId) } returns true
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user2.username, roomId = roomId.toString()))
         }
         assertEquals(HttpStatus.FORBIDDEN, ex.status)
@@ -401,7 +401,7 @@ class InviteSendTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(user1.id, roomId) } returns userRoom
         every { roomService.getRoom(roomId) } returns Optional.empty()
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user2.username, roomId = roomId.toString()))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -417,7 +417,7 @@ class InviteSendTests {
         every { roomService.getRoom(roomId) } returns Optional.of(mockk<RoomEntity>())
         every { userRepository.getUserByUsernameIgnoreCase(user2.username) } returns null
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user2.username, roomId = roomId.toString()))
         }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -434,7 +434,7 @@ class InviteSendTests {
         every { userRepository.getUserByUsernameIgnoreCase(user2.username) } returns user2
         every { userRoomRepository.existsByIdUserIdAndIdRoomId(user2.id, roomId) } returns true
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user2.username, roomId = roomId.toString()))
         }
         assertEquals(HttpStatus.CONFLICT, ex.status)
@@ -453,7 +453,7 @@ class InviteSendTests {
         every { bannedUserService.isUserBanned(user2.id, roomId) } returns false
         every { inviteRepository.existsPendingRoomInvite(user2.id, roomId) } returns true
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.sendRoomInvite(RoomInviteDTO(type = "ROOM_INVITE", targetUsername = user2.username, roomId = roomId.toString()))
         }
         assertEquals(HttpStatus.CONFLICT, ex.status)
@@ -485,7 +485,7 @@ class InviteSendTests {
     fun shouldFailToCreateOpenRoomInviteWithInvalidRoomId() {
         setAuth(user1.id)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.createOpenRoomInvite(OpenRoomInviteDTO(type = "OPEN_ROOM_INVITE", roomId = "not-a-uuid", maxUsages = 5))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -495,7 +495,7 @@ class InviteSendTests {
     fun shouldFailToCreateOpenRoomInviteWithZeroMaxUsages() {
         setAuth(user1.id)
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.createOpenRoomInvite(OpenRoomInviteDTO(type = "OPEN_ROOM_INVITE", roomId = roomId.toString(), maxUsages = 0))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -507,7 +507,7 @@ class InviteSendTests {
         every { userService.getUserById(user1.id) } returns user1
         every { roomService.getRoom(roomId) } returns Optional.empty()
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.createOpenRoomInvite(OpenRoomInviteDTO(type = "OPEN_ROOM_INVITE", roomId = roomId.toString(), maxUsages = 5))
         }
         assertEquals(HttpStatus.BAD_REQUEST, ex.status)
@@ -520,7 +520,7 @@ class InviteSendTests {
         every { roomService.getRoom(roomId) } returns Optional.of(mockk<RoomEntity>())
         every { userRoomRepository.findByIdUserIdAndIdRoomId(user1.id, roomId) } returns null
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.createOpenRoomInvite(OpenRoomInviteDTO(type = "OPEN_ROOM_INVITE", roomId = roomId.toString(), maxUsages = 5))
         }
         assertEquals(HttpStatus.NOT_FOUND, ex.status)
@@ -535,7 +535,7 @@ class InviteSendTests {
         every { roomService.getRoom(roomId) } returns Optional.of(mockk<RoomEntity>())
         every { userRoomRepository.findByIdUserIdAndIdRoomId(user1.id, roomId) } returns userRoom
 
-        val ex = assertFailsWith<ApiException> {
+        val ex = assertThrows<ApiException> {
             inviteService.createOpenRoomInvite(OpenRoomInviteDTO(type = "OPEN_ROOM_INVITE", roomId = roomId.toString(), maxUsages = 5))
         }
         assertEquals(HttpStatus.FORBIDDEN, ex.status)

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceCreationTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceCreationTests.kt
@@ -30,9 +30,9 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class RoomServiceCreationTests {
@@ -115,7 +115,7 @@ class RoomServiceCreationTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> { roomService.makeNewRoom("", false) }
+        val exception = assertThrows<ApiException> { roomService.makeNewRoom("", false) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
         assertEquals(ErrorMessages.INVALID_ROOM_NAME, exception.message)
     }
@@ -127,7 +127,7 @@ class RoomServiceCreationTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> { roomService.makeNewRoom(null, false) }
+        val exception = assertThrows<ApiException> { roomService.makeNewRoom(null, false) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
         assertEquals(ErrorMessages.INVALID_ROOM_NAME, exception.message)
     }
@@ -139,7 +139,7 @@ class RoomServiceCreationTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> { roomService.makeNewRoom("a".repeat(101), false) }
+        val exception = assertThrows<ApiException> { roomService.makeNewRoom("a".repeat(101), false) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
         assertEquals(ErrorMessages.INVALID_ROOM_NAME, exception.message)
     }
@@ -164,7 +164,7 @@ class RoomServiceCreationTests {
 
     @Test
     fun shouldFailToMakeRoomWhenNoAuthentication() {
-        val exception = assertFailsWith<ApiException> { roomService.makeNewRoom("roomName", false) }
+        val exception = assertThrows<ApiException> { roomService.makeNewRoom("roomName", false) }
         assertEquals(HttpStatus.UNAUTHORIZED, exception.status)
         assertEquals(ErrorMessages.INVALID_TOKEN, exception.message)
     }
@@ -202,7 +202,7 @@ class RoomServiceCreationTests {
 
     @Test
     fun shouldFailToGetRoomsWhenNoAuthentication() {
-        val exception = assertFailsWith<ApiException> { roomService.getAllUserRooms() }
+        val exception = assertThrows<ApiException> { roomService.getAllUserRooms() }
         assertEquals(HttpStatus.UNAUTHORIZED, exception.status)
         assertEquals(ErrorMessages.INVALID_TOKEN, exception.message)
     }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceManagementTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceManagementTests.kt
@@ -33,9 +33,9 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class RoomServiceManagementTests {
@@ -100,7 +100,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.editRoom(RoomDTO(roomId = UUID.randomUUID().toString(), encrypted = false, roomName = null, role = RoomRole.OWNER, type = RoomType.GROUP))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -113,7 +113,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.editRoom(RoomDTO(roomId = UUID.randomUUID().toString(), encrypted = false, roomName = "", role = RoomRole.OWNER, type = RoomType.GROUP))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -126,7 +126,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.editRoom(RoomDTO(roomId = UUID.randomUUID().toString(), roomName = "a".repeat(101), encrypted = false, role = RoomRole.OWNER, type = RoomType.GROUP))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -141,7 +141,7 @@ class RoomServiceManagementTests {
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
         every { userRoomRepository.findByIdUserIdAndIdRoomId(any(), any()) } returns null
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.editRoom(RoomDTO(roomId = UUID.randomUUID().toString(), encrypted = false, roomName = "real name", role = RoomRole.OWNER, type = RoomType.GROUP))
         }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -159,7 +159,7 @@ class RoomServiceManagementTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(any(), any()) } returns
                 UserRoomEntity(id = UserRoomId(userId, roomId), role = RoomRole.MEMBER, type = RoomType.GROUP)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.editRoom(RoomDTO(roomId = UUID.randomUUID().toString(), encrypted = false, roomName = "real name", role = RoomRole.OWNER, type = RoomType.GROUP))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -178,7 +178,7 @@ class RoomServiceManagementTests {
                 UserRoomEntity(id = UserRoomId(userId, roomId), role = RoomRole.OWNER, type = RoomType.GROUP)
         every { roomRepository.findById(roomId) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.editRoom(RoomDTO(roomId = roomId.toString(), encrypted = false, roomName = "real name", role = RoomRole.OWNER, type = RoomType.GROUP))
         }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -191,7 +191,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.editRoom(RoomDTO(roomId = "not a real UUID", encrypted = false, roomName = "new room name", role = RoomRole.OWNER, type = RoomType.GROUP))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -236,7 +236,7 @@ class RoomServiceManagementTests {
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns null
 
-        val exception = assertFailsWith<ApiException> { roomService.deleteRoom(roomId.toString()) }
+        val exception = assertThrows<ApiException> { roomService.deleteRoom(roomId.toString()) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -252,7 +252,7 @@ class RoomServiceManagementTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns
                 UserRoomEntity(id = UserRoomId(userId, roomId), role = RoomRole.MEMBER, type = RoomType.GROUP)
 
-        val exception = assertFailsWith<ApiException> { roomService.deleteRoom(roomId.toString()) }
+        val exception = assertThrows<ApiException> { roomService.deleteRoom(roomId.toString()) }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
     }
 
@@ -265,7 +265,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> { roomService.deleteRoom("not a real UUID") }
+        val exception = assertThrows<ApiException> { roomService.deleteRoom("not a real UUID") }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -317,7 +317,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> { roomService.getOrStartPrivateMessage(UserIdDTO("not-a-uuid")) }
+        val exception = assertThrows<ApiException> { roomService.getOrStartPrivateMessage(UserIdDTO("not-a-uuid")) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -330,7 +330,7 @@ class RoomServiceManagementTests {
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
         every { friendService.getFriendEntityById(friendId, any()) } throws UserNotFoundException()
 
-        val exception = assertFailsWith<ApiException> { roomService.getOrStartPrivateMessage(UserIdDTO(friendId.toString())) }
+        val exception = assertThrows<ApiException> { roomService.getOrStartPrivateMessage(UserIdDTO(friendId.toString())) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -345,7 +345,7 @@ class RoomServiceManagementTests {
         every { friendService.getFriendEntityById(user.id, any()) } returns user
         every { roomRepository.findById(any()) } returns Optional.empty()
 
-        val exception = assertFailsWith<ApiException> { roomService.getOrStartPrivateMessage(UserIdDTO(user.id.toString())) }
+        val exception = assertThrows<ApiException> { roomService.getOrStartPrivateMessage(UserIdDTO(user.id.toString())) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -420,7 +420,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.removeUserFromRoom(
                 AdministrationDTO(
                     roomId = UUID.randomUUID().toString(),
@@ -444,7 +444,7 @@ class RoomServiceManagementTests {
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, any()) } returns null
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.removeUserFromRoom(
                 AdministrationDTO(
                     roomId = UUID.randomUUID().toString(),
@@ -469,7 +469,7 @@ class RoomServiceManagementTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns
                 UserRoomEntity(id = UserRoomId(userId, roomId), role = RoomRole.MEMBER, type = RoomType.GROUP)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.removeUserFromRoom(
                 AdministrationDTO(
                     roomId = roomId.toString(),
@@ -491,7 +491,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.removeUserFromRoom(
                 AdministrationDTO(
                     roomId = "not-a-uuid",
@@ -513,7 +513,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.removeUserFromRoom(
                 AdministrationDTO(
                     roomId = UUID.randomUUID().toString(),
@@ -538,7 +538,7 @@ class RoomServiceManagementTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns
                 UserRoomEntity(id = UserRoomId(userId, roomId), role = RoomRole.OWNER, type = RoomType.GROUP)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.removeUserFromRoom(
                 AdministrationDTO(
                     roomId = roomId.toString(),
@@ -565,7 +565,7 @@ class RoomServiceManagementTests {
         every { roomRepository.findById(roomId) } returns Optional.empty()
         every { userRoomRepository.findUsersByRoomId(roomId) } returns emptyList()
 
-        val exception = assertFailsWith<ApiException> { roomService.deleteRoom(roomId.toString()) }
+        val exception = assertThrows<ApiException> { roomService.deleteRoom(roomId.toString()) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -602,7 +602,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> { roomService.getAllBansForRoom("not-a-uuid") }
+        val exception = assertThrows<ApiException> { roomService.getAllBansForRoom("not-a-uuid") }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -616,7 +616,7 @@ class RoomServiceManagementTests {
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, any()) } returns null
 
-        val exception = assertFailsWith<ApiException> { roomService.getAllBansForRoom(UUID.randomUUID().toString()) }
+        val exception = assertThrows<ApiException> { roomService.getAllBansForRoom(UUID.randomUUID().toString()) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -632,7 +632,7 @@ class RoomServiceManagementTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns
                 UserRoomEntity(id = UserRoomId(userId, roomId), role = RoomRole.MEMBER, type = RoomType.GROUP)
 
-        val exception = assertFailsWith<ApiException> { roomService.getAllBansForRoom(roomId.toString()) }
+        val exception = assertThrows<ApiException> { roomService.getAllBansForRoom(roomId.toString()) }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
     }
 
@@ -665,7 +665,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.unbanUser(UnbanDTO(roomId = "not-a-uuid", userId = UUID.randomUUID().toString()))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -680,7 +680,7 @@ class RoomServiceManagementTests {
 
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.unbanUser(UnbanDTO(roomId = UUID.randomUUID().toString(), userId = userId.toString()))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -696,7 +696,7 @@ class RoomServiceManagementTests {
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, any()) } returns null
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.unbanUser(UnbanDTO(roomId = UUID.randomUUID().toString(), userId = UUID.randomUUID().toString()))
         }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -714,7 +714,7 @@ class RoomServiceManagementTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns
                 UserRoomEntity(id = UserRoomId(userId, roomId), role = RoomRole.MEMBER, type = RoomType.GROUP)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.unbanUser(UnbanDTO(roomId = roomId.toString(), userId = UUID.randomUUID().toString()))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceMembershipTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceMembershipTests.kt
@@ -116,6 +116,17 @@ class RoomServiceMembershipTests {
     }
 
     @Test
+    fun shouldFailToLeaveRoomWhenUserNotFound() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(UUID.randomUUID(), null, emptyList())
+
+        every { userService.getUserById(any()) } returns null
+
+        val exception = assertThrows<ApiException> { roomService.leaveRoom(UUID.randomUUID().toString()) }
+        assertEquals(HttpStatus.BAD_REQUEST, exception.status)
+    }
+
+    @Test
     fun shouldFailToLeaveRoomWithoutBeingAMember() {
         SecurityContextHolder.getContext().authentication =
             UsernamePasswordAuthenticationToken(UUID.randomUUID(), null, emptyList())

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceMembershipTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceMembershipTests.kt
@@ -24,9 +24,9 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class RoomServiceMembershipTests {
@@ -85,7 +85,7 @@ class RoomServiceMembershipTests {
 
         every { userService.getUserById(userId) } returns null
 
-        val exception = assertFailsWith<ApiException> { roomService.joinRoom(userId, roomId) }
+        val exception = assertThrows<ApiException> { roomService.joinRoom(userId, roomId) }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -111,7 +111,7 @@ class RoomServiceMembershipTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> { roomService.leaveRoom("") }
+        val exception = assertThrows<ApiException> { roomService.leaveRoom("") }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -123,7 +123,7 @@ class RoomServiceMembershipTests {
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
         every { userRoomRepository.existsByIdUserIdAndIdRoomId(any(), any()) } returns false
 
-        val exception = assertFailsWith<ApiException> { roomService.leaveRoom(UUID.randomUUID().toString()) }
+        val exception = assertThrows<ApiException> { roomService.leaveRoom(UUID.randomUUID().toString()) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceQueryTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceQueryTests.kt
@@ -16,7 +16,10 @@ import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.redis.core.RedisTemplate
@@ -25,10 +28,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertNull
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class RoomServiceQueryTests {
@@ -121,7 +121,7 @@ class RoomServiceQueryTests {
 
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> { roomService.getAllUsersInRoom("not-a-uuid") }
+        val exception = assertThrows<ApiException> { roomService.getAllUsersInRoom("not-a-uuid") }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
     }
 
@@ -136,7 +136,7 @@ class RoomServiceQueryTests {
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns null
 
-        val exception = assertFailsWith<ApiException> { roomService.getAllUsersInRoom(roomId.toString()) }
+        val exception = assertThrows<ApiException> { roomService.getAllUsersInRoom(roomId.toString()) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
@@ -152,7 +152,7 @@ class RoomServiceQueryTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns
                 UserRoomEntity(id = UserRoomId(userId, roomId), role = RoomRole.MEMBER, type = RoomType.GROUP)
 
-        val exception = assertFailsWith<ApiException> { roomService.getAllUsersInRoom(roomId.toString()) }
+        val exception = assertThrows<ApiException> { roomService.getAllUsersInRoom(roomId.toString()) }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
     }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceRoleTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/serviceTests/roomServiceTests/RoomServiceRoleTests.kt
@@ -28,9 +28,9 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 @ExtendWith(MockKExtension::class)
 class RoomServiceRoleTests {
@@ -158,7 +158,7 @@ class RoomServiceRoleTests {
         setAuth(UUID.randomUUID())
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = UUID.randomUUID().toString(), roomId = "not-a-uuid", action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -169,7 +169,7 @@ class RoomServiceRoleTests {
         setAuth(UUID.randomUUID())
         every { userService.getUserById(any()) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = "not-a-uuid", roomId = UUID.randomUUID().toString(), action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.BAD_REQUEST, exception.status)
@@ -183,7 +183,7 @@ class RoomServiceRoleTests {
         setAuth(userId)
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = userId.toString(), roomId = roomId.toString(), action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -199,7 +199,7 @@ class RoomServiceRoleTests {
         every { userService.getUserById(userId) } returns UserEntity(username = "u", password = "")
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns null
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = targetId.toString(), roomId = roomId.toString(), action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -216,7 +216,7 @@ class RoomServiceRoleTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns userRoom(userId, roomId, RoomRole.OWNER)
         every { userRoomRepository.findByIdUserIdAndIdRoomId(targetId, roomId) } returns null
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = targetId.toString(), roomId = roomId.toString(), action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
@@ -233,7 +233,7 @@ class RoomServiceRoleTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns userRoom(userId, roomId, RoomRole.OWNER)
         every { userRoomRepository.findByIdUserIdAndIdRoomId(targetId, roomId) } returns userRoom(targetId, roomId, RoomRole.OWNER)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = targetId.toString(), roomId = roomId.toString(), action = RoleAction.DEMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -251,7 +251,7 @@ class RoomServiceRoleTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns userRoom(userId, roomId, RoomRole.MODERATOR)
         every { userRoomRepository.findByIdUserIdAndIdRoomId(targetId, roomId) } returns userRoom(targetId, roomId, RoomRole.MEMBER)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = targetId.toString(), roomId = roomId.toString(), action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -268,7 +268,7 @@ class RoomServiceRoleTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns userRoom(userId, roomId, RoomRole.OWNER)
         every { userRoomRepository.findByIdUserIdAndIdRoomId(targetId, roomId) } returns userRoom(targetId, roomId, RoomRole.ADMIN)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = targetId.toString(), roomId = roomId.toString(), action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -285,7 +285,7 @@ class RoomServiceRoleTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns userRoom(userId, roomId, RoomRole.OWNER)
         every { userRoomRepository.findByIdUserIdAndIdRoomId(targetId, roomId) } returns userRoom(targetId, roomId, RoomRole.MEMBER)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = targetId.toString(), roomId = roomId.toString(), action = RoleAction.DEMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -303,7 +303,7 @@ class RoomServiceRoleTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns userRoom(userId, roomId, RoomRole.ADMIN)
         every { userRoomRepository.findByIdUserIdAndIdRoomId(targetId, roomId) } returns userRoom(targetId, roomId, RoomRole.MODERATOR)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = targetId.toString(), roomId = roomId.toString(), action = RoleAction.PROMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -321,7 +321,7 @@ class RoomServiceRoleTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns userRoom(userId, roomId, RoomRole.ADMIN)
         every { userRoomRepository.findByIdUserIdAndIdRoomId(targetId, roomId) } returns userRoom(targetId, roomId, RoomRole.ADMIN)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = targetId.toString(), roomId = roomId.toString(), action = RoleAction.DEMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)
@@ -339,7 +339,7 @@ class RoomServiceRoleTests {
         every { userRoomRepository.findByIdUserIdAndIdRoomId(userId, roomId) } returns userRoom(userId, roomId, RoomRole.MODERATOR)
         every { userRoomRepository.findByIdUserIdAndIdRoomId(targetId, roomId) } returns userRoom(targetId, roomId, RoomRole.MODERATOR)
 
-        val exception = assertFailsWith<ApiException> {
+        val exception = assertThrows<ApiException> {
             roomService.changeRole(ChangeRoleDTO(userId = targetId.toString(), roomId = roomId.toString(), action = RoleAction.DEMOTE))
         }
         assertEquals(HttpStatus.FORBIDDEN, exception.status)

--- a/src/test/kotlin/com/blikeng/chatapp/websocketTests/SessionRegistryTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/websocketTests/SessionRegistryTests.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNull
 import org.springframework.test.util.ReflectionTestUtils
 import org.springframework.web.socket.WebSocketSession
+import java.io.IOException
 import java.util.*
 import java.util.concurrent.Executors
 
@@ -333,5 +334,84 @@ class SessionRegistryTests {
         val result = sessionRegistry.getSessionById("missing")
 
         assertNull(result)
+    }
+
+    @Test
+    fun shouldCloseAllSessionsForBannedUser(){
+        val userId = UUID.randomUUID()
+        val session1 = mockk<WebSocketSession>()
+        val session2 = mockk<WebSocketSession>()
+
+        every { session1.id } returns "s1"
+        every { session2.id } returns "s2"
+        every { session1.isOpen } returns true
+        every { session2.isOpen } returns true
+        every { session1.close() } just Runs
+        every { session2.close() } just Runs
+        every { friendService.notifyFriends(any(), any()) } just Runs
+        every { chatService.notifyRoomPresence(any(), any()) } just Runs
+
+        sessionRegistry.registerSession(userId, session1)
+        sessionRegistry.registerSession(userId, session2)
+
+        sessionRegistry.closeUserSessions(userId)
+
+        verify(exactly = 1) { session1.close() }
+        verify(exactly = 1) { session2.close() }
+    }
+
+    @Test
+    fun shouldDoNothingIfBannedUserHasNoSessions() {
+        val userId = UUID.randomUUID()
+
+        sessionRegistry.closeUserSessions(userId)
+
+        assertNull(sessionRegistry.users[userId])
+    }
+
+    @Test
+    fun shouldIgnoreIfSessionCloseFails() {
+        val userId = UUID.randomUUID()
+        val session = mockk<WebSocketSession>()
+
+        every { session.id } returns "s1"
+        every { session.isOpen } returns true
+        every { session.close() } throws IOException("boom")
+        every { friendService.notifyFriends(any(), any()) } just Runs
+        every { chatService.notifyRoomPresence(any(), any()) } just Runs
+
+        sessionRegistry.registerSession(userId, session)
+
+        assertDoesNotThrow {
+            sessionRegistry.closeUserSessions(userId)
+        }
+
+        verify(exactly = 1) { session.close() }
+    }
+
+    @Test
+    fun shouldOnlyCloseOpenSessions() {
+        val userId = UUID.randomUUID()
+        val openSession = mockk<WebSocketSession>()
+        val closedSession = mockk<WebSocketSession>()
+
+        every { openSession.id } returns "s1"
+        every { closedSession.id } returns "s2"
+
+        every { openSession.isOpen } returns true
+        every { closedSession.isOpen } returns false
+
+        every { openSession.close() } just Runs
+
+        every { friendService.notifyFriends(any(), any()) } just Runs
+        every { chatService.notifyRoomPresence(any(), any()) } just Runs
+
+        sessionRegistry.registerSession(userId, openSession)
+        sessionRegistry.registerSession(userId, closedSession)
+
+        sessionRegistry.closeUserSessions(userId)
+
+        verify(exactly = 1) { openSession.close() }
+        verify(exactly = 0) { closedSession.close() }
     }
 }

--- a/src/test/kotlin/com/blikeng/chatapp/websocketTests/websocketHandlerTests/WebsocketLifecycleTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/websocketTests/websocketHandlerTests/WebsocketLifecycleTests.kt
@@ -17,8 +17,8 @@ import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.WebSocketSession
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.test.assertFailsWith
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @ExtendWith(MockKExtension::class)
 class WebsocketLifecycleTests {
@@ -63,7 +63,7 @@ class WebsocketLifecycleTests {
     fun connectionEstablishedShouldFail() {
         every { session.attributes } returns mutableMapOf("username" to "u")
 
-        val exception = assertFailsWith<ResponseStatusException> {
+        val exception = assertThrows<ResponseStatusException> {
             handler.afterConnectionEstablished(session)
         }
 
@@ -96,7 +96,7 @@ class WebsocketLifecycleTests {
     fun connectionClosedShouldFail() {
         every { session.attributes } returns mutableMapOf("username" to "u")
 
-        val ex = assertFailsWith<ResponseStatusException> {
+        val ex = assertThrows<ResponseStatusException> {
             handler.afterConnectionClosed(session, CloseStatus.NORMAL)
         }
 

--- a/src/test/kotlin/com/blikeng/chatapp/websocketTests/websocketHandlerTests/WebsocketMessageTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/websocketTests/websocketHandlerTests/WebsocketMessageTests.kt
@@ -54,12 +54,11 @@ class WebsocketMessageTests {
 
         every { session.attributes } returns mutableMapOf("username" to "u", "userId" to UUID.randomUUID())
         every { chatService.joinRoom(any(), any()) } returns Unit
-        every { chatService.broadcast(any(), any(), any()) } returns Unit
 
         handler.handleMessage(session, payload)
 
         verify(exactly = 1) { chatService.joinRoom(any(), any()) }
-        verify(exactly = 1) { chatService.broadcast(any(), any(), any()) }
+        verify(exactly = 0) { chatService.broadcast(any(), any(), any(), any()) }
         verify(exactly = 0) { chatService.leaveRoom(any(), any()) }
     }
 
@@ -70,15 +69,12 @@ class WebsocketMessageTests {
 
         every { session.attributes } returns mutableMapOf("username" to "u", "userId" to UUID.randomUUID())
         every { chatService.leaveRoom(any(), any()) } returns Unit
-        every { chatService.broadcast(any(), any(), any()) } just Runs
         every { session.id } returns "test-session-id"
-        every { session.isOpen } returns true
-        every { session.sendMessage(any()) } just Runs
 
         handler.handleMessage(session, payload)
 
         verify(exactly = 0) { chatService.joinRoom(any(), any()) }
-        verify(exactly = 1) { chatService.broadcast(any(), any(), any()) }
+        verify(exactly = 0) { chatService.broadcast(any(), any(), any(), any()) }
         verify(exactly = 1) { chatService.leaveRoom(any(), any()) }
     }
 
@@ -88,14 +84,14 @@ class WebsocketMessageTests {
             .put("type", "MESSAGE").put("message", "m").put("roomId", UUID.randomUUID().toString()).toString())
 
         every { session.attributes } returns mutableMapOf("username" to "u", "userId" to UUID.randomUUID())
-        every { chatService.broadcast(any(), any(), any()) } returns Unit
+        every { chatService.broadcast(any(), any(), any(), any()) } just Runs
         every { session.isOpen } returns true
         every { session.sendMessage(any()) } just Runs
 
         handler.handleMessage(session, payload)
 
         verify(exactly = 0) { chatService.joinRoom(any(), any()) }
-        verify(exactly = 1) { chatService.broadcast(any(), any(), any()) }
+        verify(exactly = 1) { chatService.broadcast(any(), any(), any(), any()) }
         verify(exactly = 0) { chatService.leaveRoom(any(), any()) }
     }
 
@@ -111,8 +107,78 @@ class WebsocketMessageTests {
         handler.handleMessage(session, payload)
 
         verify(exactly = 0) { chatService.joinRoom(any(), any()) }
-        verify(exactly = 0) { chatService.broadcast(any(), any(), any()) }
+        verify(exactly = 0) { chatService.broadcast(any(), any(), any(), any()) }
         verify(exactly = 0) { chatService.leaveRoom(any(), any()) }
+    }
+
+    @Test
+    fun shouldRouteTypingMessage() {
+        val roomId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        val payload = TextMessage(objectMapper.createObjectNode()
+            .put("type", "TYPING").put("roomId", roomId.toString()).toString())
+
+        every { session.attributes } returns mutableMapOf("username" to "alice", "userId" to userId)
+        every { chatService.notifyTyping(any(), any(), any()) } just Runs
+
+        handler.handleMessage(session, payload)
+
+        verify(exactly = 1) { chatService.notifyTyping(eq(roomId), eq(userId), eq("alice")) }
+        verify(exactly = 0) { chatService.broadcast(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun shouldSendErrorOnTypingWithInvalidRoomId() {
+        val payload = TextMessage(objectMapper.createObjectNode()
+            .put("type", "TYPING").put("roomId", "not-a-uuid").toString())
+
+        every { session.attributes } returns mutableMapOf("username" to "u", "userId" to UUID.randomUUID())
+        every { session.isOpen } returns true
+        val msgSlot = slot<TextMessage>()
+        every { session.sendMessage(capture(msgSlot)) } just Runs
+
+        handler.handleMessage(session, payload)
+
+        val json = objectMapper.readTree(msgSlot.captured.payload)
+        assertEquals("ERROR", json["type"].asText())
+        assertEquals(400, json["code"].asInt())
+        verify(exactly = 0) { chatService.notifyTyping(any(), any(), any()) }
+    }
+
+    @Test
+    fun shouldSendErrorOnTypingWithoutUserId() {
+        val payload = TextMessage(objectMapper.createObjectNode()
+            .put("type", "TYPING").put("roomId", UUID.randomUUID().toString()).toString())
+
+        every { session.attributes } returns mutableMapOf("username" to "u")
+        every { session.isOpen } returns true
+        val msgSlot = slot<TextMessage>()
+        every { session.sendMessage(capture(msgSlot)) } just Runs
+
+        handler.handleMessage(session, payload)
+
+        val json = objectMapper.readTree(msgSlot.captured.payload)
+        assertEquals("ERROR", json["type"].asText())
+        assertEquals(401, json["code"].asInt())
+        verify(exactly = 0) { chatService.notifyTyping(any(), any(), any()) }
+    }
+
+    @Test
+    fun shouldSendErrorOnTypingWithoutUsername() {
+        val payload = TextMessage(objectMapper.createObjectNode()
+            .put("type", "TYPING").put("roomId", UUID.randomUUID().toString()).toString())
+
+        every { session.attributes } returns mutableMapOf("userId" to UUID.randomUUID())
+        every { session.isOpen } returns true
+        val msgSlot = slot<TextMessage>()
+        every { session.sendMessage(capture(msgSlot)) } just Runs
+
+        handler.handleMessage(session, payload)
+
+        val json = objectMapper.readTree(msgSlot.captured.payload)
+        assertEquals("ERROR", json["type"].asText())
+        assertEquals(401, json["code"].asInt())
+        verify(exactly = 0) { chatService.notifyTyping(any(), any(), any()) }
     }
 
     // ==========================
@@ -121,7 +187,7 @@ class WebsocketMessageTests {
     @Test
     fun shouldSendErrorWithoutUsername() {
         val payload = TextMessage(objectMapper.createObjectNode()
-            .put("type", "JOIN").put("roomId", UUID.randomUUID().toString()).toString())
+            .put("type", "TYPING").put("roomId", UUID.randomUUID().toString()).toString())
 
         every { session.attributes } returns mutableMapOf("userId" to UUID.randomUUID())
         every { session.isOpen } returns true
@@ -132,18 +198,19 @@ class WebsocketMessageTests {
         handler.handleMessage(session, payload)
 
         val json = objectMapper.readTree(msgSlot.captured.payload)
+
         assertEquals("ERROR", json["type"].asText())
         assertEquals(401, json["code"].asInt())
         assertEquals("No username found", json["message"].asText())
-        verify(exactly = 0) { chatService.joinRoom(any(), any()) }
+        verify(exactly = 0) { chatService.notifyTyping(any(), any(), any()) }
     }
 
     @Test
     fun shouldFailToSendMessageWithoutUserId() {
         val payload = TextMessage(objectMapper.createObjectNode()
-            .put("type", "JOIN").put("message", "m").put("roomId", UUID.randomUUID().toString()).toString())
+            .put("type", "TYPING").put("roomId", UUID.randomUUID().toString()).toString())
 
-        every { session.attributes } returns mutableMapOf("username" to "u")
+        every { session.attributes } returns mutableMapOf("username" to "user")
         every { session.isOpen } returns true
 
         val msgSlot = slot<TextMessage>()
@@ -249,7 +316,7 @@ class WebsocketMessageTests {
         assertEquals("ERROR", json["type"].asText())
         assertEquals(403, json["code"].asInt())
         assertEquals("Not permitted", json["message"].asText())
-        verify(exactly = 0) { chatService.broadcast(any(), any(), any()) }
+        verify(exactly = 0) { chatService.broadcast(any(), any(), any(), any()) }
     }
 
     @Test
@@ -259,7 +326,7 @@ class WebsocketMessageTests {
 
         every { session.attributes } returns mutableMapOf("username" to "u", "userId" to UUID.randomUUID())
         every { session.isOpen } returns true
-        every { chatService.broadcast(any(), any(), any()) } throws IllegalArgumentException("Bad request X")
+        every { chatService.broadcast(any(), any(), any(), any()) } throws IllegalArgumentException("Bad request X")
 
         val msgSlot = slot<TextMessage>()
         every { session.sendMessage(capture(msgSlot)) } just Runs
@@ -279,7 +346,7 @@ class WebsocketMessageTests {
 
         every { session.attributes } returns mutableMapOf("username" to "u", "userId" to UUID.randomUUID())
         every { session.isOpen } returns true
-        every { chatService.broadcast(any(), any(), any()) } throws RuntimeException("exception")
+        every { chatService.broadcast(any(), any(), any(), any()) } throws RuntimeException("exception")
 
         val msgSlot = slot<TextMessage>()
         every { session.sendMessage(capture(msgSlot)) } just Runs
@@ -299,7 +366,7 @@ class WebsocketMessageTests {
 
         every { session.attributes } returns mutableMapOf("username" to "u", "userId" to UUID.randomUUID())
         every { session.isOpen } returns false
-        every { chatService.broadcast(any(), any(), any()) } throws RuntimeException("exception")
+        every { chatService.broadcast(any(), any(), any(), any()) } throws RuntimeException("exception")
         every { session.sendMessage(any()) } just Runs
 
         handler.handleMessage(session, payload)
@@ -334,7 +401,7 @@ class WebsocketMessageTests {
 
         every { session.attributes } returns mutableMapOf("username" to "u", "userId" to UUID.randomUUID())
         every { session.isOpen } returns true
-        every { chatService.broadcast(any(), any(), any()) } throws IllegalArgumentException()
+        every { chatService.broadcast(any(), any(), any(), any()) } throws IllegalArgumentException()
 
         val msgSlot = slot<TextMessage>()
         every { session.sendMessage(capture(msgSlot)) } just Runs
@@ -364,7 +431,7 @@ class WebsocketMessageTests {
 
         handler.handleMessage(session, payload)
 
-        verify(exactly = 0) { chatService.broadcast(any(), any(), any()) }
+        verify(exactly = 0) { chatService.broadcast(any(), any(), any(), any()) }
 
         val json = objectMapper.readTree(msgSlot.captured.payload)
         assertEquals("ERROR", json["type"].asText())

--- a/src/test/kotlin/com/blikeng/chatapp/websocketTests/websocketHandlerTests/WebsocketMessageTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/websocketTests/websocketHandlerTests/WebsocketMessageTests.kt
@@ -19,7 +19,7 @@ import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import java.util.*
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @ExtendWith(MockKExtension::class)
 class WebsocketMessageTests {

--- a/src/test/kotlin/com/blikeng/chatapp/websocketTests/websocketHandlerTests/WebsocketSweepTests.kt
+++ b/src/test/kotlin/com/blikeng/chatapp/websocketTests/websocketHandlerTests/WebsocketSweepTests.kt
@@ -22,7 +22,7 @@ import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @ExtendWith(MockKExtension::class)
 class WebsocketSweepTests {


### PR DESCRIPTION
## Banning
* Updated banning functionality, banned users should be unable to access the site.

## Tests
* Updated all tests to use junit 6, not Kotlin wrapper

## README
* Updated readme to include new WebSocket types and notifications 

## Messages
* All online users get a notification on every message (in addition to normal WsChat)
* Client filters the notification if in room. If not in room, user gets notified
* Every user in room get typing indicator whenever a user is typing
